### PR TITLE
Add Status Effect and Potion Support

### DIFF
--- a/src/main/java/eu/pb4/polymer/interfaces/VirtualStatusEffect.java
+++ b/src/main/java/eu/pb4/polymer/interfaces/VirtualStatusEffect.java
@@ -1,0 +1,16 @@
+package eu.pb4.polymer.interfaces;
+
+import net.minecraft.entity.effect.StatusEffect;
+
+public interface VirtualStatusEffect extends VirtualObject {
+
+    /**
+     * Returns the effect to be displayed on the client's HUD.
+     * Note that particle color is determined by the server, so this will not affect them.
+     *
+     * @return Vanilla status effect, or <code>null</>null if nothing is to be displayed by the client
+     */
+    default StatusEffect getVirtualStatusEffect() {
+        return null;
+    }
+}

--- a/src/main/java/eu/pb4/polymer/item/ItemHelper.java
+++ b/src/main/java/eu/pb4/polymer/item/ItemHelper.java
@@ -14,10 +14,12 @@ import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.item.EnchantedBookItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.PotionItem;
 import net.minecraft.nbt.NbtCompound;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.nbt.NbtList;
 import net.minecraft.nbt.NbtString;
+import net.minecraft.potion.PotionUtil;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.MutableText;
@@ -79,6 +81,10 @@ public class ItemHelper {
                 if (ench instanceof VirtualObject) {
                     return createBasicVirtualItemStack(itemStack, player);
                 }
+            }
+        } else if (itemStack.getItem() instanceof PotionItem) {
+            if (PotionUtil.getPotionEffects(itemStack).stream().anyMatch(statusEffectInstance -> statusEffectInstance.getEffectType() instanceof VirtualObject)) {
+                return createBasicVirtualItemStack(itemStack, player);
             }
         }
 
@@ -188,6 +194,12 @@ public class ItemHelper {
 
             if (itemStack.hasEnchantments()) {
                 out.addEnchantment(Enchantments.VANISHING_CURSE, 0);
+            }
+
+            if (itemStack.getItem() instanceof PotionItem) {
+                if (!out.getOrCreateNbt().contains("CustomPotionColor")) {
+                    out.getOrCreateNbt().putInt("CustomPotionColor", PotionUtil.getColor(itemStack));
+                }
             }
 
             NbtElement canDestroy = itemStack.getNbt().get("CanDestroy");

--- a/src/main/java/eu/pb4/polymer/mixin/other/EntityStatusEffectS2CPacketMixin.java
+++ b/src/main/java/eu/pb4/polymer/mixin/other/EntityStatusEffectS2CPacketMixin.java
@@ -1,0 +1,27 @@
+package eu.pb4.polymer.mixin.other;
+
+import eu.pb4.polymer.interfaces.VirtualStatusEffect;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.EntityStatusEffectS2CPacket;
+import net.minecraft.util.registry.Registry;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(EntityStatusEffectS2CPacket.class)
+public class EntityStatusEffectS2CPacketMixin {
+
+    @Mutable @Shadow @Final private byte effectId;
+
+    @Inject(method = "write", at = @At("HEAD"))
+    public void polymer_onWrite(PacketByteBuf buf, CallbackInfo callbackInfo) {
+        if (Registry.STATUS_EFFECT.get(this.effectId) instanceof VirtualStatusEffect virtualEffect && virtualEffect.getVirtualStatusEffect() != null) {
+            this.effectId = (byte) (StatusEffect.getRawId(virtualEffect.getVirtualStatusEffect()) & 255);
+        }
+    }
+}

--- a/src/main/java/eu/pb4/polymer/mixin/other/RemoveEntityStatusEffectS2CPacketMixin.java
+++ b/src/main/java/eu/pb4/polymer/mixin/other/RemoveEntityStatusEffectS2CPacketMixin.java
@@ -1,0 +1,27 @@
+package eu.pb4.polymer.mixin.other;
+
+import eu.pb4.polymer.interfaces.VirtualStatusEffect;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.s2c.play.RemoveEntityStatusEffectS2CPacket;
+import net.minecraft.util.registry.Registry;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(RemoveEntityStatusEffectS2CPacket.class)
+public class RemoveEntityStatusEffectS2CPacketMixin {
+
+    @Mutable @Shadow @Final private StatusEffect effectType;
+
+    @Inject(method = "write", at = @At("HEAD"))
+    public void polymer_onWrite(PacketByteBuf buf, CallbackInfo callbackInfo) {
+        if (effectType instanceof VirtualStatusEffect virtualEffect && virtualEffect.getVirtualStatusEffect() != null) {
+            this.effectType = ((VirtualStatusEffect) effectType).getVirtualStatusEffect();
+        }
+    }
+}

--- a/src/main/java/eu/pb4/polymer/mixin/other/SynchronizeRecipesS2CPacketMixin.java
+++ b/src/main/java/eu/pb4/polymer/mixin/other/SynchronizeRecipesS2CPacketMixin.java
@@ -7,10 +7,7 @@ import net.fabricmc.api.Environment;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.network.packet.s2c.play.SynchronizeRecipesS2CPacket;
 import net.minecraft.recipe.Recipe;
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Mutable;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.*;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -24,8 +21,7 @@ import java.util.stream.Collectors;
 public abstract class SynchronizeRecipesS2CPacketMixin {
     @Unique List<Recipe<?>> rewrittenRecipes = null;
 
-    @Shadow @Mutable
-    private List<Recipe<?>> recipes;
+    @Final @Shadow @Mutable private List<Recipe<?>> recipes;
 
     @Shadow public abstract void write(PacketByteBuf buf);
 

--- a/src/main/resources/polymer.mixins.json
+++ b/src/main/resources/polymer.mixins.json
@@ -36,8 +36,10 @@
     "other.BootstrapMixin",
     "other.CommandManagerMixin",
     "other.DimensionTypeAccessor",
+    "other.EntityStatusEffectS2CPacketMixin",
     "other.IdListMixin",
     "other.RegistrySyncManagerMixin",
+    "other.RemoveEntityStatusEffectS2CPacketMixin",
     "other.ServerPlayNetworkHandlerMixin",
     "other.SynchronizeRecipesS2CPacketMixin",
     "polymc.BlockPolyGeneratorMixin"

--- a/src/testmod/java/eu/pb4/polymertest/TestMod.java
+++ b/src/testmod/java/eu/pb4/polymertest/TestMod.java
@@ -26,10 +26,13 @@ import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectInstance;
 import net.minecraft.item.*;
 import net.minecraft.nbt.NbtElement;
 import net.minecraft.network.packet.s2c.play.EntityAttributesS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
+import net.minecraft.potion.Potion;
 import net.minecraft.text.LiteralText;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Identifier;
@@ -65,6 +68,10 @@ public class TestMod implements ModInitializer {
     public static TestBowItem BOW_2 = new TestBowItem(new FabricItemSettings().group(ITEM_GROUP), "bow2");
 
     public static Enchantment ENCHANTMENT;
+
+    public static final StatusEffect STATUS_EFFECT = new TestStatusEffect();
+    public static final Potion POTION = new Potion(new StatusEffectInstance(STATUS_EFFECT, 300));
+    public static final Potion LONG_POTION = new Potion("potion", new StatusEffectInstance(STATUS_EFFECT, 600));
 
     public static final EntityType<TestEntity> ENTITY = FabricEntityTypeBuilder.<TestEntity>create(SpawnGroup.CREATURE, TestEntity::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
     public static final EntityType<TestEntity2> ENTITY_2 = FabricEntityTypeBuilder.<TestEntity2>create(SpawnGroup.CREATURE, TestEntity2::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
@@ -107,7 +114,12 @@ public class TestMod implements ModInitializer {
         Registry.register(Registry.BLOCK, new Identifier("test", "weak_glass"), WEAK_GLASS_BLOCK);
         Registry.register(Registry.ITEM, new Identifier("test", "weak_glass"), WEAK_GLASS_BLOCK_ITEM);
         Registry.register(Registry.ITEM, new Identifier("test", "ice_item"), ICE_ITEM);
+
         ENCHANTMENT = Registry.register(Registry.ENCHANTMENT, new Identifier("test", "enchantment"), new TestEnchantment());
+
+        Registry.register(Registry.STATUS_EFFECT, new Identifier("test", "effect"), STATUS_EFFECT);
+        Registry.register(Registry.POTION, new Identifier("test", "potion"), POTION);
+        Registry.register(Registry.POTION, new Identifier("test", "long_potion"), LONG_POTION);
 
         Registry.register(Registry.ENTITY_TYPE, new Identifier("test", "entity"), ENTITY);
         FabricDefaultAttributeRegistry.register(ENTITY, TestEntity.createCreeperAttributes());

--- a/src/testmod/java/eu/pb4/polymertest/TestStatusEffect.java
+++ b/src/testmod/java/eu/pb4/polymertest/TestStatusEffect.java
@@ -1,12 +1,14 @@
 package eu.pb4.polymertest;
 
 import eu.pb4.polymer.interfaces.VirtualObject;
+import eu.pb4.polymer.interfaces.VirtualStatusEffect;
 import net.minecraft.entity.EquipmentSlot;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.effect.StatusEffect;
 import net.minecraft.entity.effect.StatusEffectCategory;
+import net.minecraft.entity.effect.StatusEffects;
 
-public class TestStatusEffect extends StatusEffect implements VirtualObject {
+public class TestStatusEffect extends StatusEffect implements VirtualStatusEffect {
     protected TestStatusEffect() {
         super(StatusEffectCategory.BENEFICIAL, 110011);
     }
@@ -14,7 +16,17 @@ public class TestStatusEffect extends StatusEffect implements VirtualObject {
     @Override
     public void applyUpdateEffect(LivingEntity entity, int amplifier) {
         if (entity.getMainHandStack().isDamageable()) {
-            entity.getMainHandStack().damage(1, entity, entity1 -> entity1.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND));
+            entity.getMainHandStack().damage(amplifier + 1, entity, entity1 -> entity1.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND));
         }
+    }
+
+    @Override
+    public boolean canApplyUpdateEffect(int duration, int amplifier) {
+        return true;
+    }
+
+    @Override
+    public StatusEffect getVirtualStatusEffect() {
+        return StatusEffects.CONDUIT_POWER;
     }
 }

--- a/src/testmod/java/eu/pb4/polymertest/TestStatusEffect.java
+++ b/src/testmod/java/eu/pb4/polymertest/TestStatusEffect.java
@@ -1,0 +1,20 @@
+package eu.pb4.polymertest;
+
+import eu.pb4.polymer.interfaces.VirtualObject;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.effect.StatusEffect;
+import net.minecraft.entity.effect.StatusEffectCategory;
+
+public class TestStatusEffect extends StatusEffect implements VirtualObject {
+    protected TestStatusEffect() {
+        super(StatusEffectCategory.BENEFICIAL, 110011);
+    }
+
+    @Override
+    public void applyUpdateEffect(LivingEntity entity, int amplifier) {
+        if (entity.getMainHandStack().isDamageable()) {
+            entity.getMainHandStack().damage(1, entity, entity1 -> entity1.sendEquipmentBreakStatus(EquipmentSlot.MAINHAND));
+        }
+    }
+}

--- a/src/testmod/resources/data/polymertest/lang/en_us.json
+++ b/src/testmod/resources/data/polymertest/lang/en_us.json
@@ -1,4 +1,7 @@
 {
   "block.test.potato_block": "Tiny Potato",
-  "enchantment.test.enchantment": "TestEnch"
+  "enchantment.test.enchantment": "TestEnch",
+  "item.minecraft.potion.effect.potion": "TestPot",
+  "effect.test.effect": "Test Effect"
+
 }


### PR DESCRIPTION
By default, vanilla ignores all unknown effects on Potion tooltips, this treats all potions with a StatusEffect that extends VirtualObject (or VirtualStatusEffect for greater functionality) as virtual items. 
It also allows for VirtualStatusEffects to send a defined Vanilla effect for display in the clients HUD/Inventory screen.

TestMod has also been updated to reflect these additions.