### PR TITLE
Fix Statistic Screen Disconnect

### DIFF
--- a/src/main/java/eu/pb4/polymer/api/other/PolymerStat.java
+++ b/src/main/java/eu/pb4/polymer/api/other/PolymerStat.java
@@ -6,9 +6,9 @@ import net.minecraft.stat.Stats;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.registry.Registry;
 
-public class PolymerStat extends Identifier implements PolymerObject {
+public final class PolymerStat extends Identifier implements PolymerObject {
 
-    public PolymerStat(String id) {
+    private PolymerStat(String id) {
         super(id);
     }
 

--- a/src/main/java/eu/pb4/polymer/api/other/PolymerStat.java
+++ b/src/main/java/eu/pb4/polymer/api/other/PolymerStat.java
@@ -1,0 +1,28 @@
+package eu.pb4.polymer.api.other;
+
+import eu.pb4.polymer.api.utils.PolymerObject;
+import net.minecraft.stat.StatFormatter;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+
+public class PolymerStat extends Identifier implements PolymerObject {
+
+    public PolymerStat(String id) {
+        super(id);
+    }
+
+    /**
+     * Register a custom server-compatible statistic.
+     * Registering a {@link net.minecraft.stat.Stat} in the vanilla way will cause clients to disconnect when opening the statistics screen.
+     * @param id the Identifier for the stat
+     * @param formatter the formatter for the stat to use
+     * @return the PolymerStat ({@link Identifier}) for the custom stat
+     */
+    public static PolymerStat registerStat(String id, StatFormatter formatter) {
+        PolymerStat identifier = new PolymerStat(id);
+        Registry.register(Registry.CUSTOM_STAT, id, identifier);
+        Stats.CUSTOM.getOrCreateStat(identifier, formatter);
+        return identifier;
+    }
+}

--- a/src/main/java/eu/pb4/polymer/mixin/other/StatisticsS2CPacketMixin.java
+++ b/src/main/java/eu/pb4/polymer/mixin/other/StatisticsS2CPacketMixin.java
@@ -1,0 +1,34 @@
+package eu.pb4.polymer.mixin.other;
+
+import eu.pb4.polymer.api.utils.PolymerObject;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.network.packet.s2c.play.StatisticsS2CPacket;
+import net.minecraft.stat.Stat;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.Identifier;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(StatisticsS2CPacket.class)
+public class StatisticsS2CPacketMixin {
+
+    @Mutable
+    @Shadow @Final private Object2IntMap<Stat<?>> stats;
+
+    @Inject(method = "<init>(Lit/unimi/dsi/fastutil/objects/Object2IntMap;)V", at = @At("TAIL"))
+    public void polymer_onWrite(Object2IntMap<Stat<?>> stats, CallbackInfo ci) {
+        this.stats = stats.object2IntEntrySet().stream().filter(statEntry -> {
+            if (statEntry.getKey().getType() == Stats.CUSTOM) {
+                Identifier key = (Identifier) statEntry.getKey().getValue();
+                return !(key instanceof PolymerObject);
+            }
+            return true;
+        }).collect(Object2IntOpenHashMap::new, (map, statEntry) -> map.addTo(statEntry.getKey(), statEntry.getIntValue()), Object2IntOpenHashMap::putAll);
+    }
+}

--- a/src/main/resources/polymer.mixins.json
+++ b/src/main/resources/polymer.mixins.json
@@ -56,6 +56,7 @@
     "other.ItemGroupAccessor",
     "other.RemoveEntityStatusEffectS2CPacketMixin",
     "other.ServerPlayNetworkHandlerMixin",
+    "other.StatisticsS2CPacketMixin",
     "other.TagGroupMixin"
   ],
   "client": [

--- a/src/testmod/java/eu/pb4/polymertest/TestMod.java
+++ b/src/testmod/java/eu/pb4/polymertest/TestMod.java
@@ -4,6 +4,7 @@ import eu.pb4.polymer.api.block.SimplePolymerBlock;
 import eu.pb4.polymer.api.entity.PolymerEntityUtils;
 import eu.pb4.polymer.api.item.*;
 import eu.pb4.polymer.api.other.PolymerSoundEvent;
+import eu.pb4.polymer.api.other.PolymerStat;
 import eu.pb4.polymer.api.resourcepack.PolymerRPUtils;
 import eu.pb4.polymer.api.networking.PolymerSyncUtils;
 import eu.pb4.polymertest.mixin.EntityAccessor;
@@ -32,6 +33,8 @@ import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
 import net.minecraft.potion.Potion;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.stat.StatFormatter;
+import net.minecraft.stat.Stats;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
@@ -79,6 +82,8 @@ public class TestMod implements ModInitializer {
     public static TestBowItem BOW_2 = new TestBowItem(new FabricItemSettings().group(ITEM_GROUP), "bow2");
 
     public static Enchantment ENCHANTMENT;
+
+    public static Identifier CUSTOM_STAT;
 
     public static final StatusEffect STATUS_EFFECT = new TestStatusEffect();
     public static final StatusEffect STATUS_EFFECT_2 = new Test2StatusEffect();
@@ -164,6 +169,8 @@ public class TestMod implements ModInitializer {
 
         ENCHANTMENT = Registry.register(Registry.ENCHANTMENT, new Identifier("test", "enchantment"), new TestEnchantment());
 
+        CUSTOM_STAT = PolymerStat.registerStat("test:custom_stat", StatFormatter.DEFAULT);
+
         Registry.register(Registry.STATUS_EFFECT, new Identifier("test", "effect"), STATUS_EFFECT);
         Registry.register(Registry.STATUS_EFFECT, new Identifier("test", "effect2"), STATUS_EFFECT_2);
         Registry.register(Registry.POTION, new Identifier("test", "potion"), POTION);
@@ -193,15 +200,27 @@ public class TestMod implements ModInitializer {
 
 
 
-        CommandRegistrationCallback.EVENT.register((d, b) -> d.register(literal("test").executes((ctx) -> {
-            try {
-                ctx.getSource().sendFeedback(new LiteralText("" + PolymerRPUtils.hasPack(ctx.getSource().getPlayer())), false);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        CommandRegistrationCallback.EVENT.register((d, b) -> {
+            d.register(literal("test")
+                    .executes((ctx) -> {
+                        try {
+                            ctx.getSource().sendFeedback(new LiteralText("" + PolymerRPUtils.hasPack(ctx.getSource().getPlayer())), false);
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                        }
 
-            return 0;
-        })));
+                        return 0;
+                    })
+            );
+            d.register(literal("incrementStat")
+                    .executes((ctx) -> {
+                        ctx.getSource().getPlayer().incrementStat(CUSTOM_STAT);
+                        ctx.getSource().sendFeedback(new LiteralText("Stat now: " + ctx.getSource().getPlayer().getStatHandler().getStat(Stats.CUSTOM, CUSTOM_STAT)), false);
+
+                        return 1;
+                    })
+            );
+        });
 
 
         AtomicBoolean atomicBoolean = new AtomicBoolean(true);


### PR DESCRIPTION
This PR is to fix an issue that the vanilla client has, which causes a disconnection upon opening the Statistics screen if a modded custom statistic is sent.
A custom statistic is one which relies on the dev manually incrementing it, for example Times Enchanted, Cauldrons Filled, ect. As opposed to the automatically incremented times block mined, times item picked up, ect. (See `StatType`)

Minecraft stores custom statistics as an Identifier value in a registry (`Registry<Identifier>`) where the key is always equals to the value (because who needs lists right?). 
This implementation adds a new class which both extends `Identifier `and implements `PolymerObject`, known as `PolymerStat`. The S2C packet then removes anything found to implement `PolymerObject`.

Stats can be registered easily using the `PolymerStat#register()`  static method, which also returns the `PolymerStat` which can be used in the same way vanilla's `Stats.<Identifier>`'s can be used (`ServerPlayerEntity#incrementStat(Identifier)`, ect).

I am unsure on the way I have gone about this implementation, and am happy to adjust to feedback if required.
(Originally I just removed all Stats whose Namespace was not "minecraft", however, this can be dangerous as its easy to accidentally register something without a namespace, which defaults it back to "minecraft").

