### PR TITLE
Added PolymerRecipe to allow for client 'Recipe Unlocked' toasts to show for custom recipe types

### DIFF
--- a/src/main/java/eu/pb4/polymer/api/item/PolymerRecipe.java
+++ b/src/main/java/eu/pb4/polymer/api/item/PolymerRecipe.java
@@ -1,0 +1,105 @@
+package eu.pb4.polymer.api.item;
+
+import eu.pb4.polymer.api.utils.PolymerObject;
+import net.minecraft.item.Items;
+import net.minecraft.recipe.*;
+import net.minecraft.util.collection.DefaultedList;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Interface used for creation of server-side recipes
+ */
+public interface PolymerRecipe extends PolymerObject {
+
+    /**
+     * Returns client-side recipe used on client for specific player
+     * This allows the client to still display Recipe Unlocked toast messages to the player.
+     *
+     * The provided methods for generating a recipe unsure that the
+     * recipe will not appear in the incorrect recipe book screen.
+     * @see PolymerRecipe#createBlastingRecipe(Recipe) - For a Blast Furnace Toast Icon
+     * @see PolymerRecipe#createCraftingRecipe(Recipe) - For a Crafting Table Toast Icon
+     * @see PolymerRecipe#createCampfireCookingRecipe(Recipe) - For a Campfire Toast Icon
+     * @see PolymerRecipe#createSmeltingRecipe(Recipe) - For a Furnace Toast Icon
+     * @see PolymerRecipe#createSmithingRecipe(Recipe) - For a Smithing Table Toast Icon
+     * @see PolymerRecipe#createSmokingRecipe(Recipe) - For a Smoker Toast Icon
+     * @see PolymerRecipe#createStonecuttingRecipe(Recipe) - For a Stonecutter Toast Icon
+     *
+     * @param input Server-sided recipe to be converted
+     * @return Vanilla (or other) Recipe instance, or null if the recipe is hidden from the client
+     */
+    @Nullable
+    default Recipe<?> getPolymerRecipe(Recipe<?> input) {
+        return createCraftingRecipe(input);
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#BLASTING}.
+     * Icon Used: {@link Items#BLAST_FURNACE}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createBlastingRecipe(Recipe<?> input) {
+        return new BlastingRecipe(input.getId(), "impossible", Ingredient.EMPTY, input.getOutput(), 0, 0);
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#CRAFTING}.
+     * Icon Used: {@link Items#CRAFTING_TABLE}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createCraftingRecipe(Recipe<?> input) {
+        return new ShapelessRecipe(input.getId(), "impossible", input.getOutput(), DefaultedList.of());
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#CAMPFIRE_COOKING}.
+     * Icon Used: {@link Items#CAMPFIRE}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createCampfireCookingRecipe(Recipe<?> input) {
+        return new CampfireCookingRecipe(input.getId(), "impossible", Ingredient.EMPTY, input.getOutput(), 0, 0);
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#SMELTING}.
+     * Icon Used: {@link Items#FURNACE}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createSmeltingRecipe(Recipe<?> input) {
+        return new SmeltingRecipe(input.getId(), "impossible", Ingredient.EMPTY, input.getOutput(), 0, 0);
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#SMITHING}.
+     * Icon Used: {@link Items#SMITHING_TABLE}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createSmithingRecipe(Recipe<?> input) {
+        return new SmithingRecipe(input.getId(), Ingredient.EMPTY, Ingredient.EMPTY, input.getOutput());
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#SMOKING}.
+     * Icon Used: {@link Items#SMOKER}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createSmokingRecipe(Recipe<?> input) {
+        return new SmokingRecipe(input.getId(), "impossible", Ingredient.EMPTY, input.getOutput(), 0, 0);
+    }
+
+    /**
+     * Make the client display as a {@link RecipeType#STONECUTTING}.
+     * Icon Used: {@link Items#STONECUTTER}
+     * @param input the Modded recipe
+     * @return the Vanilla recipe
+     */
+    static Recipe<?> createStonecuttingRecipe(Recipe<?> input) {
+        return new StonecuttingRecipe(input.getId(), "impossible", Ingredient.EMPTY, input.getOutput());
+    }
+}

--- a/src/main/java/eu/pb4/polymer/mixin/item/packet/SynchronizeRecipesS2CPacketMixin.java
+++ b/src/main/java/eu/pb4/polymer/mixin/item/packet/SynchronizeRecipesS2CPacketMixin.java
@@ -1,5 +1,6 @@
 package eu.pb4.polymer.mixin.item.packet;
 
+import eu.pb4.polymer.api.item.PolymerRecipe;
 import eu.pb4.polymer.api.utils.PolymerObject;
 import io.netty.buffer.Unpooled;
 import net.fabricmc.api.EnvType;
@@ -17,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Mixin(SynchronizeRecipesS2CPacket.class)
 public abstract class SynchronizeRecipesS2CPacketMixin {
@@ -28,9 +28,16 @@ public abstract class SynchronizeRecipesS2CPacketMixin {
     @Shadow public abstract void write(PacketByteBuf buf);
 
     @Inject(method = "<init>(Ljava/util/Collection;)V", at = @At("TAIL"))
-    public void polymer_onWrite(Collection<Recipe<?>> recipes, CallbackInfo ci) {
+    public void polymer_onInit(Collection<Recipe<?>> recipes, CallbackInfo ci) {
         List<Recipe<?>> list = new ArrayList<>();
         for (Recipe<?> recipe : recipes) {
+            if (recipe instanceof PolymerRecipe) {
+                Recipe<?>  polymerRecipe = ((PolymerRecipe) recipe).getPolymerRecipe(recipe);
+                if (polymerRecipe != null) {
+                    list.add(polymerRecipe);
+                    continue;
+                }
+            }
             if (!(PolymerObject.is(recipe.getSerializer()) || PolymerObject.is(recipe))) {
                 list.add(recipe);
             }

--- a/src/testmod/java/eu/pb4/polymertest/TestMod.java
+++ b/src/testmod/java/eu/pb4/polymertest/TestMod.java
@@ -3,10 +3,10 @@ package eu.pb4.polymertest;
 import eu.pb4.polymer.api.block.SimplePolymerBlock;
 import eu.pb4.polymer.api.entity.PolymerEntityUtils;
 import eu.pb4.polymer.api.item.*;
+import eu.pb4.polymer.api.networking.PolymerSyncUtils;
 import eu.pb4.polymer.api.other.PolymerSoundEvent;
 import eu.pb4.polymer.api.other.PolymerStat;
 import eu.pb4.polymer.api.resourcepack.PolymerRPUtils;
-import eu.pb4.polymer.api.networking.PolymerSyncUtils;
 import eu.pb4.polymertest.mixin.EntityAccessor;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.block.FabricBlockSettings;
@@ -19,7 +19,10 @@ import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.Material;
 import net.minecraft.enchantment.Enchantment;
-import net.minecraft.entity.*;
+import net.minecraft.entity.EntityDimensions;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.SpawnGroup;
 import net.minecraft.entity.attribute.EntityAttributeInstance;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -31,6 +34,8 @@ import net.minecraft.nbt.NbtElement;
 import net.minecraft.network.packet.s2c.play.EntityAttributesS2CPacket;
 import net.minecraft.network.packet.s2c.play.EntityTrackerUpdateS2CPacket;
 import net.minecraft.potion.Potion;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.stat.StatFormatter;
@@ -84,6 +89,9 @@ public class TestMod implements ModInitializer {
     public static Enchantment ENCHANTMENT;
 
     public static Identifier CUSTOM_STAT;
+
+    public static final RecipeType<TestRecipe> TEST_RECIPE_TYPE = RecipeType.register("test:test");
+    public static final RecipeSerializer<TestRecipe> TEST_RECIPE_SERIALIZER = new TestRecipe.Serializer();
 
     public static final StatusEffect STATUS_EFFECT = new TestStatusEffect();
     public static final StatusEffect STATUS_EFFECT_2 = new Test2StatusEffect();
@@ -170,6 +178,8 @@ public class TestMod implements ModInitializer {
         ENCHANTMENT = Registry.register(Registry.ENCHANTMENT, new Identifier("test", "enchantment"), new TestEnchantment());
 
         CUSTOM_STAT = PolymerStat.registerStat("test:custom_stat", StatFormatter.DEFAULT);
+
+        Registry.register(Registry.RECIPE_SERIALIZER, new Identifier("test", "test"), TEST_RECIPE_SERIALIZER);
 
         Registry.register(Registry.STATUS_EFFECT, new Identifier("test", "effect"), STATUS_EFFECT);
         Registry.register(Registry.STATUS_EFFECT, new Identifier("test", "effect2"), STATUS_EFFECT_2);

--- a/src/testmod/java/eu/pb4/polymertest/TestRecipe.java
+++ b/src/testmod/java/eu/pb4/polymertest/TestRecipe.java
@@ -1,0 +1,84 @@
+package eu.pb4.polymertest;
+
+import com.google.gson.JsonObject;
+import eu.pb4.polymer.api.item.PolymerRecipe;
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.recipe.ShapedRecipe;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+
+public class TestRecipe implements Recipe<Inventory>, PolymerRecipe {
+
+    private final Identifier id;
+    private final ItemStack output;
+
+    public TestRecipe(Identifier id, ItemStack output) {
+        this.id = id;
+        this.output = output;
+    }
+
+    @Override
+    public Recipe<?> getPolymerRecipe(Recipe<?> input) {
+        return PolymerRecipe.createStonecuttingRecipe(input);
+    }
+
+    @Override
+    public boolean matches(Inventory inventory, World world) {
+        return false;
+    }
+
+    @Override
+    public ItemStack craft(Inventory inventory) {
+        return this.output.copy();
+    }
+
+    @Override
+    public boolean fits(int width, int height) {
+        return false;
+    }
+
+    @Override
+    public ItemStack getOutput() {
+        return this.output;
+    }
+
+    @Override
+    public Identifier getId() {
+        return this.id;
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return TestMod.TEST_RECIPE_SERIALIZER;
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return TestMod.TEST_RECIPE_TYPE;
+    }
+
+    public static class Serializer implements RecipeSerializer<TestRecipe> {
+
+        @Override
+        public TestRecipe read(Identifier id, JsonObject json) {
+            ItemStack output = ShapedRecipe.outputFromJson(json.getAsJsonObject("output"));
+            return new TestRecipe(id, output);
+        }
+
+        @Override
+        public TestRecipe read(Identifier id, PacketByteBuf buf) {
+            ItemStack output = buf.readItemStack();
+            return new TestRecipe(id, output);
+        }
+
+        @Override
+        public void write(PacketByteBuf buf, TestRecipe recipe) {
+            buf.writeItemStack(recipe.output);
+        }
+    }
+}

--- a/src/testmod/resources/data/polymertest/recipes/test.json
+++ b/src/testmod/resources/data/polymertest/recipes/test.json
@@ -1,0 +1,6 @@
+{
+  "type": "test:test",
+  "output": {
+    "item": "minecraft:barrier"
+  }
+}


### PR DESCRIPTION
Adds the PolymerRecipe interface which is allows custom Recipes to implement the `getPolymerRecipe` to modify what is sent to the client. This means that recipes can be sent to the client under a vanilla serialiser, rather than not at all.
This means that:
1. The client will show 'Recipe Unlocked' toasts when custom recipes are unlocked
2. The recipes identifier will appear in command suggestions such as /recipe.

The implementation allows devs to easily choose which Vanilla serialiser (mainly used for the toast icon) to send to the client using the helper methods (as noted in Java doc), or null to keep present behaviour of hiding custom recipes completely from the client.

By using a non-standard recipe group ('impossible' used here), it will also hide them from there respective recipe books. The exception to this is smithing, however it does not have a recipe book widget in its GUI presently, so this is a non-issue.

I have also updated the test mod to reflect these additions.