### PR TITLE
Add attribute filtering at a packet level

### DIFF
--- a/polymer/src/main/java/eu/pb4/polymer/mixin/block/packet/ThreadedAnvilChunkStorageAccessor.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/block/packet/ThreadedAnvilChunkStorageAccessor.java
@@ -3,6 +3,7 @@ package eu.pb4.polymer.mixin.block.packet;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import net.minecraft.network.packet.s2c.play.ChunkDataS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import net.minecraft.world.chunk.WorldChunk;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -12,6 +13,10 @@ import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(ThreadedAnvilChunkStorage.class)
 public interface ThreadedAnvilChunkStorageAccessor {
+
+    @Accessor("world")
+    ServerWorld getWorld();
+
     @Accessor
     int getWatchDistance();
 

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityAttachedPacketsMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityAttachedPacketsMixin.java
@@ -13,7 +13,8 @@ import org.spongepowered.asm.mixin.Unique;
         EntityTrackerUpdateS2CPacket.class,
         MobSpawnS2CPacket.class,
         EntitySetHeadYawS2CPacket.class,
-        EntityEquipmentUpdateS2CPacket.class
+        EntityEquipmentUpdateS2CPacket.class,
+        EntityAttributesS2CPacket.class
 })
 public class EntityAttachedPacketsMixin implements EntityAttachedPacket {
     @Unique

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityAttributesS2CPacketMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityAttributesS2CPacketMixin.java
@@ -1,0 +1,37 @@
+package eu.pb4.polymer.mixin.entity;
+
+import eu.pb4.polymer.api.entity.PolymerEntity;
+import eu.pb4.polymer.impl.entity.InternalEntityHelpers;
+import eu.pb4.polymer.impl.interfaces.EntityAttachedPacket;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import net.minecraft.entity.attribute.DefaultAttributeRegistry;
+import net.minecraft.network.packet.s2c.play.EntityAttributesS2CPacket;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import java.util.Collection;
+import java.util.List;
+
+@Mixin(EntityAttributesS2CPacket.class)
+public abstract class EntityAttributesS2CPacketMixin {
+
+    @SuppressWarnings("unchecked")
+    @ModifyArg(method = "write", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;writeCollection(Ljava/util/Collection;Ljava/util/function/BiConsumer;)V", ordinal = 0))
+    private Collection<EntityAttributesS2CPacket.Entry> polymer_replaceWithPolymer(Collection<EntityAttributesS2CPacket.Entry> value) {
+        if (EntityAttachedPacket.get(this) instanceof PolymerEntity entity) {
+            if (!InternalEntityHelpers.isLivingEntity(entity.getPolymerEntityType())) {
+                return List.of();
+            }
+
+            DefaultAttributeContainer vanillaContainer = DefaultAttributeRegistry.get((EntityType<? extends LivingEntity>) entity.getPolymerEntityType());
+            return value.stream().filter(entry -> vanillaContainer.has(entry.getId())).toList();
+        }
+
+        return value;
+    }
+}

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityAttributesS2CPacketMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityAttributesS2CPacketMixin.java
@@ -8,9 +8,7 @@ import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.attribute.DefaultAttributeContainer;
 import net.minecraft.entity.attribute.DefaultAttributeRegistry;
 import net.minecraft.network.packet.s2c.play.EntityAttributesS2CPacket;
-import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
@@ -19,6 +17,18 @@ import java.util.List;
 
 @Mixin(EntityAttributesS2CPacket.class)
 public abstract class EntityAttributesS2CPacketMixin {
+
+    /**
+     * If the entity is not living, use an invalid entity ID so the client ignores it.
+     * No error is printed, packet is just silently ignored.
+     */
+    @ModifyArg(method = "write", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;writeVarInt(I)Lnet/minecraft/network/PacketByteBuf;"))
+    private int polymer_replaceWithPolymer(int input) {
+        if (EntityAttachedPacket.get(this) instanceof PolymerEntity entity && !InternalEntityHelpers.isLivingEntity(entity.getPolymerEntityType())) {
+            return -1;
+        }
+        return input;
+    }
 
     @SuppressWarnings("unchecked")
     @ModifyArg(method = "write", at = @At(value = "INVOKE", target = "Lnet/minecraft/network/PacketByteBuf;writeCollection(Ljava/util/Collection;Ljava/util/function/BiConsumer;)V", ordinal = 0))

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityTrackerEntryMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityTrackerEntryMixin.java
@@ -29,10 +29,7 @@ import java.util.function.Consumer;
 
 @Mixin(EntityTrackerEntry.class)
 public abstract class EntityTrackerEntryMixin {
-    @Shadow
-    @Final
-    private Entity entity;
-
+    @Shadow @Final private Entity entity;
     @Shadow @Final private Consumer<Packet<?>> receiver;
 
     @ModifyVariable(method = "sendPackets", at = @At("HEAD"))

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityTrackerEntryMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityTrackerEntryMixin.java
@@ -14,7 +14,6 @@ import net.minecraft.network.packet.s2c.play.EntityEquipmentUpdateS2CPacket;
 import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.EntityTrackingListener;
-import net.minecraft.util.math.Vec3d;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -23,10 +22,11 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Set;
 import java.util.function.Consumer;
 
-@SuppressWarnings({"removal"})
 @Mixin(EntityTrackerEntry.class)
 public abstract class EntityTrackerEntryMixin {
     @Shadow
@@ -39,14 +39,6 @@ public abstract class EntityTrackerEntryMixin {
     private Consumer<Packet<?>> polymer_packetWrap(Consumer<Packet<?>> packetConsumer) {
         return (packet) -> packetConsumer.accept(EntityAttachedPacket.set(packet, this.entity));
     }
-
-    /*@ModifyVariable(method = "sendPackets", at = @At(value = "INVOKE_ASSIGN", target = "Lnet/minecraft/entity/attribute/AttributeContainer;getAttributesToSend()Ljava/util/Collection;"))
-    private Collection<EntityAttributeInstance> polymer_sendAttributesOnlyForLivingVirtual(Collection<EntityAttributeInstance> attributes) {
-        if (this.entity instanceof PolymerEntity entity && !InternalEntityHelpers.isLivingEntity(entity.getPolymerEntityType())) {
-            return Collections.emptyList();
-        }
-        return attributes;
-    }*/
 
     @Inject(method = "sendPackets", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;createSpawnPacket()Lnet/minecraft/network/Packet;"))
     private void polymer_sendPacketsBeforeSpawning(Consumer<Packet<?>> sender, CallbackInfo ci) {

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityTrackerMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/entity/EntityTrackerMixin.java
@@ -3,25 +3,26 @@ package eu.pb4.polymer.mixin.entity;
 import eu.pb4.polymer.impl.interfaces.MetaConsumer;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.Packet;
+import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.world.EntityTrackingListener;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.server.world.ThreadedAnvilChunkStorage;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.Set;
 import java.util.function.Consumer;
 
 @Mixin(ThreadedAnvilChunkStorage.EntityTracker.class)
 public abstract class EntityTrackerMixin {
+
     @Shadow @Final private Set<EntityTrackingListener> listeners;
 
-    @Shadow @Final private Entity entity;
-
-    @ModifyArg(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/EntityTrackerEntry;<init>(Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/entity/Entity;IZLjava/util/function/Consumer;)V"))
-    private Consumer<Packet<?>> polymer_replaceReceiver(Consumer<Packet<?>> receiver) {
-        return MetaConsumer.plsFixInDevRemappingFabric((ThreadedAnvilChunkStorage.EntityTracker) (Object) this, this.listeners, this.entity);
+    @Redirect(method = "<init>", at = @At(value = "NEW", target = "net/minecraft/server/network/EntityTrackerEntry"))
+    private EntityTrackerEntry polymer_replaceReceiver(ServerWorld world, Entity entity, int tickInterval, boolean alwaysUpdateVelocity, Consumer<Packet<?>> receiver) {
+        return new EntityTrackerEntry(world, entity, tickInterval, alwaysUpdateVelocity, MetaConsumer.plsFixInDevRemappingFabric((ThreadedAnvilChunkStorage.EntityTracker) (Object) this, this.listeners, entity));
     }
 }

--- a/polymer/src/main/resources/polymer.mixins.json
+++ b/polymer/src/main/resources/polymer.mixins.json
@@ -42,6 +42,7 @@
     "entity.DataTrackerAccessor",
     "entity.EntityAccessor",
     "entity.EntityAttachedPacketsMixin",
+    "entity.EntityAttributesS2CPacketMixin",
     "entity.EntityPositionS2CPacketMixin",
     "entity.EntitySetHeadYawS2CPacketMixin",
     "entity.EntitySpawnS2CPacketMixin",

--- a/polymer/src/testmod/java/eu/pb4/polymertest/TestEntity.java
+++ b/polymer/src/testmod/java/eu/pb4/polymertest/TestEntity.java
@@ -20,8 +20,6 @@ public class TestEntity extends CreeperEntity implements PolymerEntity {
         super(entityEntityType, world);
     }
 
-    public TestEntity(World world) { super(TestMod.ENTITY, world); }
-
     @Override
     public EntityType<?> getPolymerEntityType() {
         return EntityType.VILLAGER;

--- a/polymer/src/testmod/java/eu/pb4/polymertest/TestEntity3.java
+++ b/polymer/src/testmod/java/eu/pb4/polymertest/TestEntity3.java
@@ -1,0 +1,34 @@
+package eu.pb4.polymertest;
+
+import eu.pb4.polymer.api.entity.PolymerEntity;
+import eu.pb4.polymertest.mixin.EntityAccessor;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.data.DataTracker;
+import net.minecraft.entity.mob.CreeperEntity;
+import net.minecraft.network.Packet;
+import net.minecraft.network.packet.s2c.play.EntitySpawnS2CPacket;
+import net.minecraft.world.World;
+
+import java.util.List;
+
+public class TestEntity3 extends CreeperEntity implements PolymerEntity {
+    public TestEntity3(EntityType<TestEntity3> entityEntityType, World world) {
+        super(entityEntityType, world);
+    }
+
+    @Override
+    public EntityType<?> getPolymerEntityType() {
+        return EntityType.FIREBALL;
+    }
+
+    @Override
+    public Packet<?> createSpawnPacket() {
+        return new EntitySpawnS2CPacket(this);
+    }
+
+    @Override
+    public void modifyTrackedData(List<DataTracker.Entry<?>> data) {
+        data.add(new DataTracker.Entry<>(EntityAccessor.getNO_GRAVITY(), true));
+    }
+
+}

--- a/polymer/src/testmod/java/eu/pb4/polymertest/TestMod.java
+++ b/polymer/src/testmod/java/eu/pb4/polymertest/TestMod.java
@@ -121,8 +121,9 @@ public class TestMod implements ModInitializer, ClientModInitializer {
     public static final Potion LONG_POTION = new Potion("potion", new StatusEffectInstance(STATUS_EFFECT, 600));
     public static final Potion LONG_POTION_2 = new Potion("potion", new StatusEffectInstance(STATUS_EFFECT_2, 600));
 
-    public static final EntityType<TestEntity> ENTITY = FabricEntityTypeBuilder.<TestEntity>create(SpawnGroup.CREATURE, TestEntity::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
-    public static final EntityType<TestEntity2> ENTITY_2 = FabricEntityTypeBuilder.<TestEntity2>create(SpawnGroup.CREATURE, TestEntity2::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
+    public static final EntityType<TestEntity> ENTITY = FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TestEntity::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
+    public static final EntityType<TestEntity2> ENTITY_2 = FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TestEntity2::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
+    public static final EntityType<TestEntity3> ENTITY_3 = FabricEntityTypeBuilder.create(SpawnGroup.CREATURE, TestEntity3::new).dimensions(EntityDimensions.fixed(0.75f, 1.8f)).build();
 
     public static final Item TEST_ENTITY_EGG = new PolymerSpawnEggItem(ENTITY, Items.COW_SPAWN_EGG, new Item.Settings().group(ITEM_GROUP));
     public static final Item TEST_FOOD = new SimplePolymerItem(new Item.Settings().group(ITEM_GROUP).food(new FoodComponent.Builder().hunger(10).saturationModifier(20).build()), Items.POISONOUS_POTATO);
@@ -234,7 +235,10 @@ public class TestMod implements ModInitializer, ClientModInitializer {
         register(Registry.ENTITY_TYPE, new Identifier("test", "entity2"), ENTITY_2);
         FabricDefaultAttributeRegistry.register(ENTITY_2, TestEntity2.createCreeperAttributes());
 
-        PolymerEntityUtils.registerType(ENTITY, ENTITY_2);
+        register(Registry.ENTITY_TYPE, new Identifier("test", "entity3"), ENTITY_3);
+        FabricDefaultAttributeRegistry.register(ENTITY_3, TestEntity3.createMobAttributes().add(EntityAttributes.HORSE_JUMP_STRENGTH));
+
+        PolymerEntityUtils.registerType(ENTITY, ENTITY_2, ENTITY_3);
 
         PolymerItemUtils.ITEM_CHECK.register((itemStack) -> itemStack.hasNbt() && itemStack.getNbt().contains("Test", NbtElement.STRING_TYPE));
 

--- a/polymer/src/testmod/java/eu/pb4/polymertest/TestMod.java
+++ b/polymer/src/testmod/java/eu/pb4/polymertest/TestMod.java
@@ -229,7 +229,7 @@ public class TestMod implements ModInitializer, ClientModInitializer {
         register(Registry.POTION, new Identifier("test", "long_potion_2"), LONG_POTION_2);
 
         register(Registry.ENTITY_TYPE, new Identifier("test", "entity"), ENTITY);
-        FabricDefaultAttributeRegistry.register(ENTITY, TestEntity.createCreeperAttributes());
+        FabricDefaultAttributeRegistry.register(ENTITY, TestEntity.createCreeperAttributes().add(EntityAttributes.GENERIC_LUCK));
 
         register(Registry.ENTITY_TYPE, new Identifier("test", "entity2"), ENTITY_2);
         FabricDefaultAttributeRegistry.register(ENTITY_2, TestEntity2.createCreeperAttributes());

--- a/polymer/src/testmod/java/eu/pb4/polymertest/mixin/EntityAccessor.java
+++ b/polymer/src/testmod/java/eu/pb4/polymertest/mixin/EntityAccessor.java
@@ -13,4 +13,9 @@ public interface EntityAccessor {
     static TrackedData<Integer> getFROZEN_TICKS() {
         throw new UnsupportedOperationException();
     }
+
+    @Accessor
+    static TrackedData<Boolean> getNO_GRAVITY() {
+        throw new UnsupportedOperationException();
+    }
 }


### PR DESCRIPTION
Superceding #27 

The client will log a warning when reciving an atrribute entry for a mob which does not have said attribute.
This fixes this by filtering out attributes that the vanilla entitiy does not hold.