### PR TITLE
Prevent need for temporary PolyMc folder

### DIFF
--- a/polymer/src/main/java/eu/pb4/polymer/api/resourcepack/PolymerRPUtils.java
+++ b/polymer/src/main/java/eu/pb4/polymer/api/resourcepack/PolymerRPUtils.java
@@ -168,11 +168,7 @@ public final class PolymerRPUtils {
             if (CompatStatus.POLYMC) {
                 try {
                     Files.createDirectories(path);
-                    PolyMcHelpers.createResources("polymc-generated");
-                    var polyPath = FabricLoader.getInstance().getGameDir().resolve("polymc-generated").toAbsolutePath();
-                    if (polyPath.toFile().exists()) {
-                        builder.copyFromPath(polyPath);
-                    }
+                    PolyMcHelpers.importPolyMcResources(builder);
                 } catch(Exception e){
                     e.printStackTrace();
                 }


### PR DESCRIPTION
This writes the PolyMc files straight into byte arrays, instead of writing them into a temporary file first. Technically it could be made more efficient by writing them straight into the zip but I don't think it's a major issue.