### PR TITLE
Fix custom payload mixin issue

### DIFF
--- a/polymer/src/main/java/eu/pb4/polymer/mixin/other/ServerPlayNetworkHandlerMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/other/ServerPlayNetworkHandlerMixin.java
@@ -195,10 +195,11 @@ public abstract class ServerPlayNetworkHandlerMixin implements PolymerNetworkHan
         return this.polymer_protocolMap;
     }
 
-    @Inject(method = "onCustomPayload", at = @At("HEAD"))
+    @Inject(method = "onCustomPayload", at = @At("HEAD"), cancellable = true)
     private void polymer_catchPackets(CustomPayloadC2SPacket packet, CallbackInfo ci) {
         if (packet.getChannel().getNamespace().equals(PolymerUtils.ID)) {
             PolymerServerProtocolHandler.handle((ServerPlayNetworkHandler) (Object) this, packet.getChannel(), packet.getData());
+            ci.cancel();
         }
     }
 


### PR DESCRIPTION
Though `onCustomPayload` method is empty on server side, still need to be canceled since other mods may inject this method too. 