### PR TITLE
Fix WTHIT compatibility

### DIFF
--- a/polymer-core/src/main/resources/fabric.mod.json
+++ b/polymer-core/src/main/resources/fabric.mod.json
@@ -61,7 +61,7 @@
     },
     "waila:plugins": {
       "id": "polymer:main",
-      "initializer": "eu.pb4.polymer.impl.client.compat.WthitCompatibility"
+      "initializer": "eu.pb4.polymer.core.impl.client.compat.WthitCompatibility"
     }
   }
 }


### PR DESCRIPTION
The `core` addition was missing from the `initializer` line in _fabric.mod.json_ (in polymer-core, obviously).