### PR TITLE
Fix sync on Velocity servers (1.19.1)

### DIFF
--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/ResourcePackNetworkHandler.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/ResourcePackNetworkHandler.java
@@ -13,9 +13,6 @@ import net.minecraft.network.packet.c2s.play.PlayPongC2SPacket;
 import net.minecraft.network.packet.c2s.play.ResourcePackStatusC2SPacket;
 import net.minecraft.network.packet.s2c.play.*;
 import net.minecraft.text.Text;
-import net.minecraft.world.GameMode;
-
-import java.util.Optional;
 
 public class ResourcePackNetworkHandler extends EarlyPlayNetworkHandler {
     private final boolean required;
@@ -34,8 +31,7 @@ public class ResourcePackNetworkHandler extends EarlyPlayNetworkHandler {
         if (PolymerRPUtils.hasPack(player)) {
             this.continueJoining();
         } else {
-            var server = this.getServer();
-            this.sendPacket(new GameJoinS2CPacket(player.getId(), false, GameMode.SPECTATOR, null, server.getWorldRegistryKeys(), server.getRegistryManager(), server.getOverworld().getDimensionKey(), server.getOverworld().getRegistryKey(), 0, server.getPlayerManager().getMaxPlayerCount(), 2, 2, false, false, false, true, Optional.empty()));
+            this.sendInitialGameJoin();
 
             //this.sendPacket(new ChunkDataS2CPacket(FAKE_CHUNK, PolymerUtils.getFakeWorld().getLightingProvider(), null, null, true));
             this.sendPacket(FAKE_ENTITY.createSpawnPacket());

--- a/polymer-reg-sync-manipulator/src/main/java/eu/pb4/polymer/rsm/impl/CompatStatus.java
+++ b/polymer-reg-sync-manipulator/src/main/java/eu/pb4/polymer/rsm/impl/CompatStatus.java
@@ -10,11 +10,4 @@ public final class CompatStatus {
     public static final boolean FABRIC_SYNC = LOADER.isModLoaded("fabric-registry-sync-v0");
 
     public static final boolean QUILT_REGISTRY = LOADER.isModLoaded("quilt_registry");
-
-    public static final boolean FABRIC_PROXY_LITE = LOADER.isModLoaded("fabricproxy-lite");
-    public static final boolean FABRIC_PROXY_LEGACY = LOADER.isModLoaded("fabricproxy-legacy");
-    public static final boolean FABRIC_PROXY = LOADER.isModLoaded("fabricproxy");
-    public static final boolean QFORWARD = LOADER.isModLoaded("qforward");
-
-    public static final boolean PROXY_MODS = FABRIC_PROXY || FABRIC_PROXY_LEGACY || FABRIC_PROXY_LITE || QFORWARD;
 }

--- a/polymer-reg-sync-manipulator/src/main/java/eu/pb4/polymer/rsm/impl/CompatStatus.java
+++ b/polymer-reg-sync-manipulator/src/main/java/eu/pb4/polymer/rsm/impl/CompatStatus.java
@@ -10,4 +10,11 @@ public final class CompatStatus {
     public static final boolean FABRIC_SYNC = LOADER.isModLoaded("fabric-registry-sync-v0");
 
     public static final boolean QUILT_REGISTRY = LOADER.isModLoaded("quilt_registry");
+
+    public static final boolean FABRIC_PROXY_LITE = LOADER.isModLoaded("fabricproxy-lite");
+    public static final boolean FABRIC_PROXY_LEGACY = LOADER.isModLoaded("fabricproxy-legacy");
+    public static final boolean FABRIC_PROXY = LOADER.isModLoaded("fabricproxy");
+    public static final boolean QFORWARD = LOADER.isModLoaded("qforward");
+
+    public static final boolean PROXY_MODS = FABRIC_PROXY || FABRIC_PROXY_LEGACY || FABRIC_PROXY_LITE || QFORWARD;
 }

--- a/polymer/src/main/java/eu/pb4/polymer/impl/compat/CompatStatus.java
+++ b/polymer/src/main/java/eu/pb4/polymer/impl/compat/CompatStatus.java
@@ -29,6 +29,13 @@ public final class CompatStatus {
     public static final boolean JEI = LOADER.isModLoaded("jei");
     public static final boolean EMI = LOADER.isModLoaded("emi");
 
+    public static final boolean FABRIC_PROXY_LITE = LOADER.isModLoaded("fabricproxy-lite");
+    public static final boolean FABRIC_PROXY_LEGACY = LOADER.isModLoaded("fabricproxy-legacy");
+    public static final boolean FABRIC_PROXY = LOADER.isModLoaded("fabricproxy");
+    public static final boolean QFORWARD = LOADER.isModLoaded("qforward");
+
+    public static final boolean PROXY_MODS = FABRIC_PROXY || FABRIC_PROXY_LEGACY || FABRIC_PROXY_LITE || QFORWARD;
+
     public static final boolean IRIS = LOADER.isModLoaded("iris");
     public static final boolean CANVAS = LOADER.isModLoaded("canvas");
     public static final boolean OPTIBAD = LOADER.isModLoaded("optifabric");

--- a/polymer/src/main/java/eu/pb4/polymer/impl/networking/NetConfig.java
+++ b/polymer/src/main/java/eu/pb4/polymer/impl/networking/NetConfig.java
@@ -1,0 +1,6 @@
+package eu.pb4.polymer.impl.networking;
+
+public class NetConfig {
+    public String _c1 = "Sends GameJoin packet, only enable if sync does work (most likely for servers under proxy)";
+    public boolean sendGameJoinBeforeSync = false;
+}

--- a/polymer/src/main/java/eu/pb4/polymer/impl/networking/NetImpl.java
+++ b/polymer/src/main/java/eu/pb4/polymer/impl/networking/NetImpl.java
@@ -1,7 +1,7 @@
 package eu.pb4.polymer.impl.networking;
 
 import eu.pb4.polymer.impl.PolymerImpl;
-import eu.pb4.polymer.rsm.impl.CompatStatus;
+import eu.pb4.polymer.impl.compat.CompatStatus;
 
 public class NetImpl {
     public static final boolean SEND_GAME_JOIN_PACKET;

--- a/polymer/src/main/java/eu/pb4/polymer/impl/networking/NetImpl.java
+++ b/polymer/src/main/java/eu/pb4/polymer/impl/networking/NetImpl.java
@@ -1,0 +1,14 @@
+package eu.pb4.polymer.impl.networking;
+
+import eu.pb4.polymer.impl.PolymerImpl;
+import eu.pb4.polymer.rsm.impl.CompatStatus;
+
+public class NetImpl {
+    public static final boolean SEND_GAME_JOIN_PACKET;
+
+    static {
+        var config = PolymerImpl.loadConfig("networking", NetConfig.class);
+
+        SEND_GAME_JOIN_PACKET = config.sendGameJoinBeforeSync || CompatStatus.PROXY_MODS;
+    }
+}

--- a/polymer/src/main/java/eu/pb4/polymer/mixin/client/ClientPlayNetworkHandlerMixin.java
+++ b/polymer/src/main/java/eu/pb4/polymer/mixin/client/ClientPlayNetworkHandlerMixin.java
@@ -55,7 +55,7 @@ public abstract class ClientPlayNetworkHandlerMixin {
     private void polymer_handleHackfest(KeepAliveS2CPacket packet, CallbackInfo ci) {
         // Yes, it's a hack but it works quite well!
         // I should replace it with some api later
-        if (packet.getId() == PolymerHandshakeHandlerImplLogin.MAGIC_VALUE) {
+        if (packet.getId() == PolymerHandshakeHandlerImplLogin.MAGIC_INIT_VALUE) {
             PolymerClientProtocol.sendHandshake((ClientPlayNetworkHandler) (Object) this);
         }
     }


### PR DESCRIPTION
Partial backport of Patbox/polymer@3d83cd3f296ac520ab5903d2674f6097750c4344 to the 1.19.1 branch.

Also adds detection for [FabricProxy-Legacy](https://github.com/voruti/FabricProxy-Legacy).

(see QuiltMC/quilted-fabric-api/issues/46)