### PR TITLE
Update list of mods using Polymer

### DIFF
--- a/MODS.md
+++ b/MODS.md
@@ -1,130 +1,327 @@
 # Mods using Polymer
-Some mods/ports using Polymer, ordered alphabetically
+A list of server-side Fabric/Quilt mods using Polymer, ordered alphabetically.
 
-## Brewery
-Brewery is a Fabric/Quilt compatible mod allowing you to create alcoholic and non-alcoholic drinks 
-with cauldrons and barrels. Aside of few builtin ones, you can add any number of custom drinks with 
-their own recipes and functionality by using datapacks. Additionally, this mod can work purely server side, 
-allowing vanilla clients to join and use its capabilities.
+
+## Advanced Golems (1.19.4)
+*Advanced Golems* adds a small golem that helps the player defend an area from hostile mobs.
 
 ### Links:
-- Github: https://github.com/Patbox/brewery
+- GitHub: https://github.com/Flemmli97/AdvancedGolems
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/advanced-golems-fabric
+
+
+## Amazing Chest (1.19.2)
+*Amazing Chest* adds a new "Sorting Chest" block to your world that will will automatically pull matching items
+into itself from any connected hopper chain.
+
+### Links:
+- GitHub: https://github.com/pcal43/amazing-chest
+- Modrinth: https://modrinth.com/mod/amazing-chest
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/amazing-chest
+
+
+## Brewery (1.20.1 / latest)
+*Brewery* allows you to create alcoholic and non-alcoholic drinks with cauldrons and barrels.
+Aside from a few that are built-in, you can add any number of custom drinks with their own recipes and functionality
+using datapacks. Additionally, this mod can work purely server side, allowing vanilla clients to join and use
+its capabilities.
+
+### Links:
+- GitHub: https://github.com/Patbox/brewery
 - Modrinth: https://modrinth.com/mod/brewery
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/patboxs-brewery
 
-## ComputerCraft: Restitched with Polymer
-This is a port of CC: Restitched (which by itself is port of CC: Tweaked, continuation of original ComputerCraft), 
-modified in a way to allow nearly all functionality of regular version to work purely server side 
-(Vanilla client can join servers using it and have all functionality!). 
-It still requires server to run on Fabric or Quilt, so keep that in mind!
+
+## ComputerCraft: Restitched with Polymer (1.19.4)
+This is a port of [CC: Restitched](https://modrinth.com/mod/cc-restitched) (which by itself is port of [CC: Tweaked](https://modrinth.com/mod/cc-tweaked), continuation of the original [ComputerCraft](https://modrinth.com/mod/computercraft)),
+modified in a way to allow nearly all functionality of the regular version to work purely server-side.
+(Vanilla clients can join servers using it and have all functionality!)
 
 ### Links:
-- Github: https://github.com/PolymerPorts/cc-restitched
+- GitHub: https://github.com/PolymerPorts/cc-restitched
 - Modrinth: https://modrinth.com/mod/cc-polymer
 
-## FabricAutoCrafter
-This mod adds a new block, the AutoCrafter. 
-It allows you to put items in the crafting table and get an output. 
+
+## Eldritch Mobs (1.19.2)
+*Eldritch Mobs* is a port of [AtomicStryker's Infernal Mobs](https://www.curseforge.com/minecraft/mc-mods/atomicstrykers-infernal-mobs).
+This mod randomly imbues mobs in your world with powerful abilities that make them more challenging to fight.
+
+### Links:
+- GitHub: https://github.com/HyperPigeon/Eldritch-Mobs
+- Modrinth: https://modrinth.com/mod/eldritch-mobs
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/eldritch-mobs
+
+
+## FabricAutoCrafter (1.20.1 / latest)
+*FabricAutoCrafter* adds a new block, the AutoCrafter.
+It allows you to put items in the crafting table and get an output.
 Hoppers and droppers do interact with the table.
 
 ### Links:
-- Github: https://github.com/QPCrummer/FabricAutoCrafter
+- GitHub: https://github.com/Tater-Certified/FabricAutoCrafter
 - Modrinth: https://modrinth.com/mod/fabricautocrafter
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/fabricautocrafter
 
-## Fabric Waystones (Polymer Ports)
-A Fabric mod for Minecraft that adds waystones - a new way of transportation, 
-that let you teleport from one discovered waystone to another.
+
+## Fabric Waystones (Polymer Ports) (1.19)
+*Fabric Waystones* adds waystones - a new way of transportation that lets players teleport from one discovered waystone to another.
 
 ### Links:
-- Github: https://github.com/PolymerPorts/FabricWaystones
+- GitHub: https://github.com/PolymerPorts/FabricWaystones
 - Modrinth: https://modrinth.com/mod/polymer-ports-waystones
 
-## Get Off My Lawn ReServed
-*Get Off My Lawn ReServer* is a take on the popular concept of player claims for Survival/Freebuild Fabric servers.
-This mod works fully server side (no client mod required!) while being compatible with major Fabric modpacks
 
-This project is a fork [Get Off My Lawn by Draylar](https://github.com/Draylar/get-off-my-lawn), with main focus on improving and building on top of original.
+## FlashFreeze (1.19)
+*FlashFreeze* allows server administrators to add and remove content-adding mods without dropping any blocks, entities or items.
+You can use it to migrate to a newer version of Minecraft without waiting for That One Last Mod,
+or turn content mods on and off one by one to nail down that pesky bug.
 
 ### Links:
-- Github: https://github.com/Patbox/get-off-my-lawn-reserved
+- GitHub: https://github.com/BasiqueEvangelist/FlashFreeze
+- Modrinth: https://modrinth.com/mod/flashfreeze
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/flashfreeze
+
+
+## Get Off My Lawn ReServed (1.20.1 / latest)
+*Get Off My Lawn ReServed* is a take on the popular concept of player claims for Survival/Freebuild servers.
+This mod works fully server-side (no client mod required!) while being compatible with major Fabric modpacks.
+
+This project is a fork [Get Off My Lawn by Draylar](https://github.com/Draylar/get-off-my-lawn), with a main focus
+on improving and building on top of the original.
+
+### Links:
+- GitHub: https://github.com/Patbox/get-off-my-lawn-reserved
 - Modrinth: https://modrinth.com/mod/goml-reserved
-- CurseForge: https://www.curseforge.com/minecraft/mc-mods/get-off-my-lawn-reserved/
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/get-off-my-lawn-reserved
 
-## Illager Expansion (Polymer Port)
-Illager Expansion is mod focused around bringing more content to the mysterious Illagers in minecraft. 
-From new strucutres to mobs and items we have you covered. Will you be able to find all of the secrets 
-of the Illagers before its to late?
+
+## Grappling Hook (1.18.1)
+*Grappling Hook* adds a grappling hook. (unfinished)
 
 ### Links:
-- Github: https://github.com/PolymerPorts/Illager-Expansion-Rematch
+- GitHub: https://github.com/Skydale/GrapplingHook
+
+
+## Grimoire (1.19.4)
+*Grimoire* is a Fabric server-side mod that enhances the item upgrade mechanism,
+featuring custom enchantments, items, and recipes.
+
+### Links:
+- GitHub: https://github.com/phomc/grimoire
+- Modrinth: https://modrinth.com/mod/grimoire
+
+
+## Illager Expansion (Polymer Port) (1.19.2)
+*Illager Expansion* is mod focused around bringing more content to the mysterious Illagers.
+Featuring new structures, mobs, and items, we have you covered. Will you be able to find all secrets
+of the Illagers before it's too late?
+
+### Links:
+- GitHub: https://github.com/PolymerPorts/Illager-Expansion-Rematch
 - Modrinth: https://modrinth.com/mod/illager-expansion-polymer
 
 
-## Interdimensional
-Interdimensional allows you to create custom dimensions from an intuitive command interface,
-without needing to install the mod on your client!
+## Interdimensional (1.17.1)
+*Interdimensional* allows you to create custom dimensions from an intuitive command interface.
 
 ### Links:
-- Github: https://github.com/QuiltServerTools/Interdimensional
+- GitHub: https://github.com/QuiltServerTools/Interdimensional
 - Modrinth: https://modrinth.com/mod/interdimensional
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/interdimensional
 
-## Jump Vader
-It's a mod that lets you place "Jump Vader" blocks similar to the Quark mod's elevators. 
-You simply place one above the other at any vertical distance, and jump/crouch on top of the block 
-to go in between the different heights.
+
+## Jump Vader (1.19.2)
+*Jump Vader* is a mod that lets you place "Jump Vader" blocks similar to the OpenBlocks mod's elevators.
+You simply place one above the other at any vertical distance, and jump/sneak on top of the block
+to go between the different heights.
 
 ### Links:
-- Github: https://github.com/VenomCodeDev/JumpVaderMod
+- GitHub: https://github.com/VenomCodeDev/JumpVaderMod
 - Modrinth: https://modrinth.com/mod/jumpvader
 
-## Lightning Podoboo
-Makes fire created by natural lightning cosmetic, meaning no blocks are destroyed from bad weather.  
+
+## LifeSteal (1.19.2)
+*LifeSteal* is an implementation of [LifeSteal SMP](https://store.lifestealsmp.com).
+> We are a semi-vanilla Minecraft server with an additional feature where you can steal hearts from other players.
+> When you kill another player, you receive their heart while they lose a heart.
+> This means that you will now have 1 more total heart, and the victim will have 1 less. 
+
+### Links:
+- GitHub: https://github.com/Tater-Certified/LifeSteal
+- Modrinth: https://modrinth.com/mod/life-steal
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/lifesteal
+
+
+## Lightning Podoboo (1.20.1 / latest)
+*Lightning Podoboo* makes fire created by natural lightning cosmetic, meaning no blocks are destroyed from bad weather.
 Keep the `doFireTick` gamerule enabled without worrying about random fire destroying your builds or nearby trees!
 
 ### Links
-- Github: https://github.com/LostLuma/Lightning-Podoboo
+- GitHub: https://github.com/LostLuma/Lightning-Podoboo
 - Modrinth: https://modrinth.com/mod/lightning-podoboo
 
-## Server Backpacks
-A mod that adds server-side backpacks.
+
+## Map Render (1.19.2)
+*Map Render* adds a Doom-like renderer using maps. (unfinished)
 
 ### Links:
-- Github: https://github.com/Oliver-makes-code/server-backpacks
+- GitHub: https://github.com/Oliver-makes-code/MapRender
+- Modrinth: https://modrinth.com/mod/maprender
+- CurseForge:
+
+
+## Nox (1.19.2)
+*Nox* is a mob and difficulty overhaul striving to make a return to when nights were scary, legitimately threatening,
+and a present threat.
+
+### Links:
+- GitHub: https://github.com/stormdirus2/nox
+- Modrinth: https://modrinth.com/mod/nox
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/nox-a-mob-and-difficulty-overhaul
+
+
+## Packy (1.19.2)
+*Packy* is a mod made for [ModFest: Singularity](https://modrinth.com/modpack/modfest-singularity) that adds backpacks
+that lets players access their ender chest from anywhere.
+
+### Links:
+- GitHub: https://github.com/NotNite/packy
+- Modrinth: https://modrinth.com/mod/packy
+
+
+## Polysit (1.20.1 / latest)
+*Polysit* allows you to right-click to sit on slabs or stairs.
+
+### Links:
+- GitHub: https://github.com/Modflower/polysit
+- Modrinth: https://modrinth.com/mod/polysit
+
+
+## Power Networks (1.19.4)
+*Power Networks* adds coils and wires that the player can use to build energy transfer networks.
+(does not include any energy producers or consumers)
+
+### Links:
+- GitHub: https://github.com/MattiDragon/PowerNetworks
+- Modrinth: https://modrinth.com/mod/power-networks
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/power-networks
+
+
+## Random Serverside Blocks (1.18.1)
+*Random Serverside Blocks* adds random server-side blocks. A list can be found at the Modrinth link.
+
+### Links:
+- GitHub: https://github.com/ayumi-chizuru189/Random-Server-Blocks
+- Modrinth: https://modrinth.com/mod/randomserverblocks
+
+
+## Server Backpacks (1.17.1)
+*Server Backpacks* is a mod that adds server-side backpacks.
+
+### Links:
+- GitHub: https://github.com/Oliver-makes-code/server-backpacks
 - Modrinth: https://modrinth.com/mod/servback
 
-## TaterCart
-This mod changes minecart physics (with option to toggle it per minecart 
-for people who need vanilla physics) and adds multiple new one with their own functionality!
+
+## ServerMobs (1.19.2)
+Including crocodiles and gusts, a whirlwind that loves to throw you in the air, *ServerMobs* is a good demonstration
+of the capabilities of the [ServerMobs API](https://modrinth.com/mod/server_mobs_api).
+Oh, and there's missiles. For added fun!
 
 ### Links:
-- Github: https://github.com/Patbox/TaterCart
-- Modrinth: https://modrinth.com/mod/tatercart
+- GitHub: https://github.com/techno-sam/ServerMobs
+- Modrinth: https://modrinth.com/mod/server_mobs
 
-## Trinkets (Polymer Port)
-A data-driven accessory mod for Minecraft using Fabric.
+
+## Set Bonuses (1.17.1)
+*Set Bonuses* adds fully configurable enchantments and set bonuses.
 
 ### Links:
-- Github: https://github.com/PolymerPorts/trinkets
-- Modrinth: https://modrinth.com/mod/trinkets-polymer
+- GitHub: https://github.com/CodedSakura/SetBonuses
+- Modrinth: https://modrinth.com/mod/set-bonuses
 
-## Simple Villagers
-Having frustrations with villagers? No more!
+
+## Simple Villagers (1.20 / latest)
+Having frustrations with villagers? No more! *Simple Villagers* adds several utilities to
+ease trading with villagers, including rerolling trades, simpler forms of villager transportation,
+and various blocks to speed up breeding and curing.
 
 ### Links:
 - GitHub: https://github.com/samolego/SimpleVillagers
 - Modrinth: https://modrinth.com/mod/simplevillagers
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/simplevillagers
 
-## Universal Graves
-It's a simple, but really customisable grave/death chest mod! 
-You can customise as you like, by modifying message, blocks and hologram texts, 
-how long it will be protected, if should drop items after expiring and alike.
+
+## Spice of Fabric (1.19.3)
+With *Spice of Fabric,* as you eat food, the nutrition value of the different kinds of food will decrease,
+so you're forced to have a diverse diet.
+By default, the last 20 meals are considered when calculating the nutrition values and the drop in the nutrition
+will be pretty rapid.
+If you're not a friend of that, then rest assured, *all used formulas are totally configurable.* You can either edit
+the config file manually or use ModMenu to access the config screen.
+There's also the so-called "Carrot Mode" which is highly inspired by [Spice Of Life: Carrot Edition](https://www.curseforge.com/minecraft/mc-mods/spice-of-life-carrot-edition).
 
 ### Links:
-- Github: https://github.com/Patbox/UniversalGraves
+- GitHub: https://github.com/Siphalor/spiceoffabric
+- Modrinth: https://modrinth.com/mod/spice-of-fabric
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/spice-of-fabric
+
+
+## TaterCart (1.19)
+*TaterCart* changes minecart physics (with the option to toggle it per minecart
+for people who need vanilla physics) and adds multiple new minecarts with their own functionality!
+
+### Links:
+- GitHub: https://github.com/Patbox/TaterCart
+- Modrinth: https://modrinth.com/mod/tatercart
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/tatercart
+
+
+## Taterzens (1.20.1 / latest)
+*Taterzens* allows you to create custom NPCs that can have custom commands, walk around, and talk (and more is to come).
+
+### Links:
+- GitHub: https://github.com/samolego/Taterzens
+- Modrinth: https://modrinth.com/mod/taterzens
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/taterzens
+
+
+## Trinkets (Polymer Port) (1.19.4)
+*Trinkets* is a data-driven accessory mod for Minecraft using Fabric.
+
+### Links:
+- GitHub: https://github.com/PolymerPorts/trinkets
+- Modrinth: https://modrinth.com/mod/trinkets-polymer
+
+
+## Universal Graves (1.20.1 / latest)
+*Universal Graves* is a simple, but really customizable grave/death chest mod!
+You can customize as you like, by modifying messages, blocks, and hologram texts,
+how long graves will be protected, whether items should be dropped after expiring, etc.
+
+### Links:
+- GitHub: https://github.com/Patbox/UniversalGraves
 - Modrinth: https://modrinth.com/mod/universal-graves
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/universal-graves
 
 
-#### Your mod is missing? Feel free to create an issue or pr it!
+## Universal Shops (1.20.1 / latest)
+*Universal Shops* is a trade shop mod designed to be flexible and usable in many types of servers.
+It includes craftable Trade Shop blocks for players and Admin Trade Shop blocks for admins/map makers. Setup of both is the same.
+It also checks against Common Protection API to make sure players have access to source chests/containers.
+
+### Links:
+- GitHub: https://github.com/Patbox/UniversalShops
+- Modrinth: https://modrinth.com/mod/universal-shops
+- CurseForge: https://www.curseforge.com/minecraft/mc-mods/universal-shops
+
+
+## YetAnotherAuthMod (1.19.3)
+*YetAnotherAuthMod* is a Minecraft mod that provides a simple authentication system for Minecraft servers.
+It creates a limbo world where the player can login or register, after which they'll will be sent to the main world.
+
+### Links:
+- GitHub: https://github.com/Skidamek/YetAnotherAuthMod
+
+
+#### Is your mod is missing? Feel free to create an issue or PR it!

--- a/MODS.md
+++ b/MODS.md
@@ -179,6 +179,13 @@ and a present threat.
 - Modrinth: https://modrinth.com/mod/nox
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/nox-a-mob-and-difficulty-overhaul
 
+## Nox: Renoxed (1.20.1 / latest)
+*Nox: Renoxed* is a continuation of *Nox* for Minecraft 1.20 and beyond.
+
+### Links:
+- GitHub: https://github.com/qxeii/nox-renoxed
+- Modrinth: https://modrinth.com/mod/nox-renoxed
+
 
 ## Packy (1.19.2)
 *Packy* is a mod made for [ModFest: Singularity](https://modrinth.com/modpack/modfest-singularity) that adds backpacks

--- a/MODS.md
+++ b/MODS.md
@@ -167,7 +167,6 @@ Keep the `doFireTick` gamerule enabled without worrying about random fire destro
 ### Links:
 - GitHub: https://github.com/Oliver-makes-code/MapRender
 - Modrinth: https://modrinth.com/mod/maprender
-- CurseForge:
 
 
 ## Nox (1.19.2)
@@ -284,15 +283,6 @@ for people who need vanilla physics) and adds multiple new minecarts with their 
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/tatercart
 
 
-## Taterzens (1.20.1 / latest)
-*Taterzens* allows you to create custom NPCs that can have custom commands, walk around, and talk (and more is to come).
-
-### Links:
-- GitHub: https://github.com/samolego/Taterzens
-- Modrinth: https://modrinth.com/mod/taterzens
-- CurseForge: https://www.curseforge.com/minecraft/mc-mods/taterzens
-
-
 ## Trinkets (Polymer Port) (1.19.4)
 *Trinkets* is a data-driven accessory mod for Minecraft using Fabric.
 
@@ -321,14 +311,6 @@ It also checks against Common Protection API to make sure players have access to
 - GitHub: https://github.com/Patbox/UniversalShops
 - Modrinth: https://modrinth.com/mod/universal-shops
 - CurseForge: https://www.curseforge.com/minecraft/mc-mods/universal-shops
-
-
-## YetAnotherAuthMod (1.19.3)
-*YetAnotherAuthMod* is a Minecraft mod that provides a simple authentication system for Minecraft servers.
-It creates a limbo world where the player can login or register, after which they'll will be sent to the main world.
-
-### Links:
-- GitHub: https://github.com/Skidamek/YetAnotherAuthMod
 
 
 #### Is your mod is missing? Feel free to create an issue or PR it!


### PR DESCRIPTION
This should be all of them.

Adds:
- Advanced Golems
- Amazing Chest
- Eldritch Mobs
- FlashFreeze
- Grappling Hook
- Grimoire
- LifeSteal
- Map Render
- Nox
- Nox: Renoxed
- Packy
- Polysit
- Power Networks
- Random Serverside Blocks
- ServerMobs
- Set Bonuses
- Spice of Fabric
- Tatercart
- ~~Taterzens~~
- Universal Shops
- ~~YetAnotherAuthMod~~

Also adds the latest supported Minecraft version of each mod (which is likely doomed to fall out of date), updates some mod links, and fixes and standardizes grammar in a lot of places.