### PR TITLE
Fix ElementHolder position delta always being zero

### DIFF
--- a/polymer-virtual-entity/src/main/java/eu/pb4/polymer/virtualentity/api/ElementHolder.java
+++ b/polymer-virtual-entity/src/main/java/eu/pb4/polymer/virtualentity/api/ElementHolder.java
@@ -162,7 +162,7 @@ public class ElementHolder {
         var newPos = this.attachment.getPos();
 
         if (!this.currentPos.equals(newPos)) {
-            var delta = newPos.subtract(newPos);
+            var delta = newPos.subtract(this.currentPos);
             this.notifyElementsOfPositionUpdate(newPos, delta);
             this.currentPos = newPos;
             this.currentChunkPos = null;


### PR DESCRIPTION
Fixes a small bug where the delta position when updating the ElementHolders position is always calculated to be zero.