### PR TITLE
autohost: Stop HttpServer when stopping MinecraftServer

### DIFF
--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/api/ResourcePackDataProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/api/ResourcePackDataProvider.java
@@ -15,6 +15,7 @@ public interface ResourcePackDataProvider {
     JsonElement saveSettings();
     void loadSettings(JsonElement settings);
     void serverStarted(MinecraftServer server);
+    void serverStopped(MinecraftServer server);
 
     static ResourcePackDataProvider getActive() {
         return AutoHost.provider;

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/AutoHost.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/AutoHost.java
@@ -57,6 +57,10 @@ public class AutoHost implements ModInitializer {
         provider.serverStarted(server);
     }
 
+    public static void end(MinecraftServer server) {
+        provider.serverStopped(server);
+    }
+
     public static void generateAndCall(MinecraftServer server, Consumer<Text> messageConsumer, Runnable runnable) {
         Util.getIoWorkerExecutor().execute(() -> {
             messageConsumer.accept(Text.literal("Starting resource pack generation..."));

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/EmptyProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/EmptyProvider.java
@@ -38,4 +38,9 @@ public record EmptyProvider() implements ResourcePackDataProvider {
     public void serverStarted(MinecraftServer server) {
 
     }
+
+    @Override
+    public void serverStopped(MinecraftServer server) {
+
+    }
 }

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/WebServerProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/WebServerProvider.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 
 public class WebServerProvider implements ResourcePackDataProvider {
     private Config config;
+    private HttpServer server;
     public long size = 0;
     public String hash = "";
     public long lastUpdate = 0;
@@ -35,7 +36,7 @@ public class WebServerProvider implements ResourcePackDataProvider {
     public void serverStarted(MinecraftServer minecraftServer) {
         try {
             var address = createBindAddress(minecraftServer, config);
-            var server = HttpServer.create(address, 0);
+            server = HttpServer.create(address, 0);
 
             server.createContext("/", this::handle);
             server.setExecutor(Executors.newFixedThreadPool(2));
@@ -63,6 +64,11 @@ public class WebServerProvider implements ResourcePackDataProvider {
         } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    @Nullable
+    public void serverStopped(MinecraftServer minecraftServer) {
+        server.stop(0);
     }
 
     private void updateHash() {

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/mixin/MinecraftServerMixin.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/mixin/MinecraftServerMixin.java
@@ -13,4 +13,9 @@ public class MinecraftServerMixin {
     private void polymer_autohost_init(CallbackInfo ci) {
         AutoHost.init((MinecraftServer) (Object) this);
     }
+
+    @Inject(method = "shutdown", at = @At("TAIL"))
+    private void polymer_autohost_end(CallbackInfo ci) {
+        AutoHost.end((MinecraftServer) (Object) this);
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where, when using Polymer's `autohost` module to automatically generate and host a resource pack via a built-in web server, the server would hang until manually interrupted when stopped via the `/stop` command.

The added `@Inject` uses the same injection point as Fabric API's `ServerLifecycleEvents.SERVER_STOPPED`.

(this targets `dev/1.20` instead of `dev/1.20.2` because QFAPI (my use case) still hasn't updated yet; it should be mergeable as-is to the latter branch though)