### PR TITLE
Fix WTHIT compatibility

### DIFF
--- a/polymer-core/build.gradle
+++ b/polymer-core/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
 
     modCompileOnly /*modLocalRuntime*/("maven.modrinth:jade:14.1.0+fabric")
-    modCompileOnly /*modLocalRuntime*/("mcp.mobius.waila:wthit:fabric-11.1.3")
+    modCompileOnly modLocalRuntime("mcp.mobius.waila:wthit:fabric-11.999-local")
 
     modCompileOnly /*modLocalRuntime*/ ("me.shedaniel:RoughlyEnoughItems-fabric:15.0.728")
     modCompileOnly /*modLocalRuntime*/("dev.emi:emi-fabric:1.1.6+1.20.6")

--- a/polymer-core/build.gradle
+++ b/polymer-core/build.gradle
@@ -53,7 +53,7 @@ dependencies {
 
 
     modCompileOnly /*modLocalRuntime*/("maven.modrinth:jade:14.1.0+fabric")
-    modCompileOnly modLocalRuntime("mcp.mobius.waila:wthit:fabric-11.999-local")
+    modCompileOnly /*modLocalRuntime*/("mcp.mobius.waila:wthit:fabric-11.2.0")
 
     modCompileOnly /*modLocalRuntime*/ ("me.shedaniel:RoughlyEnoughItems-fabric:15.0.728")
     modCompileOnly /*modLocalRuntime*/("dev.emi:emi-fabric:1.1.6+1.20.6")

--- a/polymer-core/src/main/java/eu/pb4/polymer/core/impl/client/compat/WthitCompatibility.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/impl/client/compat/WthitCompatibility.java
@@ -25,14 +25,15 @@ import org.jetbrains.annotations.Nullable;
 
 @ApiStatus.Internal
 public class WthitCompatibility implements IWailaPlugin {
-    private static final Identifier BLOCK_STATES = Identifier.tryParse("waila:show_states");
+    private static final Identifier BLOCK_STATES = Identifier.tryParse("attribute.block_state");
 
     @Override
     public void register(IRegistrar registrar) {
+        registrar.addRedirect(BlockOverride.INSTANCE, Block.class, 400);
         registrar.addComponent(BlockOverride.INSTANCE, TooltipPosition.HEAD, Block.class, 100000);
         registrar.addComponent(BlockOverride.INSTANCE, TooltipPosition.BODY, Block.class, 100000);
         registrar.addComponent(BlockOverride.INSTANCE, TooltipPosition.TAIL, Block.class, 100000);
-        registrar.addOverride(BlockOverride.INSTANCE, Block.class, 1000);
+        registrar.addIcon(BlockOverride.INSTANCE, Block.class, 500);
 
         registrar.addComponent(ItemEntityOverride.INSTANCE, TooltipPosition.HEAD, ItemEntity.class, 100000);
         registrar.addComponent(ItemEntityOverride.INSTANCE, TooltipPosition.TAIL, ItemEntity.class, 100000);
@@ -56,7 +57,13 @@ public class WthitCompatibility implements IWailaPlugin {
         public static final BlockOverride INSTANCE = new BlockOverride();
 
         @Override
-        public ITooltipComponent getIcon(IBlockAccessor accessor, IPluginConfig config) {
+        public @Nullable ITargetRedirector.Result redirect(ITargetRedirector redirect, IBlockAccessor accessor, IPluginConfig config) {
+            if (InternalClientRegistry.getBlockAt(accessor.getPosition()) != ClientPolymerBlock.NONE_STATE) return redirect.toSelf();
+            return null;
+        }
+
+        @Override
+        public @Nullable ITooltipComponent getIcon(IBlockAccessor accessor, IPluginConfig config) {
             var block = InternalClientRegistry.getBlockAt(accessor.getPosition());
             if (block != ClientPolymerBlock.NONE_STATE) {
                 BlockState state = accessor.getWorld().getBlockState(accessor.getPosition());
@@ -73,7 +80,7 @@ public class WthitCompatibility implements IWailaPlugin {
 
                 return new ItemComponent(itemStack);
             }
-            return EmptyComponent.INSTANCE;
+            return null;
         }
 
         @Override
@@ -162,6 +169,12 @@ public class WthitCompatibility implements IWailaPlugin {
 
     private static final class EntityOverride implements IEntityComponentProvider {
         public static final EntityOverride INSTANCE = new EntityOverride();
+
+        @Override
+        public @Nullable ITargetRedirector.Result redirect(ITargetRedirector redirect, IEntityAccessor accessor, IPluginConfig config) {
+            if (PolymerClientUtils.getEntityType(accessor.getEntity()) != null) return redirect.toSelf();
+            return null;
+        }
 
         @Override
         public void appendHead(ITooltip tooltip, IEntityAccessor accessor, IPluginConfig config) {

--- a/polymer-core/src/main/java/eu/pb4/polymer/core/mixin/client/compat/wthit_HarvestProviderMixin.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/mixin/client/compat/wthit_HarvestProviderMixin.java
@@ -1,0 +1,22 @@
+package eu.pb4.polymer.core.mixin.client.compat;
+
+import eu.pb4.polymer.core.api.client.ClientPolymerBlock;
+import eu.pb4.polymer.core.impl.client.InternalClientRegistry;
+import mcp.mobius.waila.api.IBlockAccessor;
+import mcp.mobius.waila.api.IPluginConfig;
+import mcp.mobius.waila.api.ITooltip;
+import mcp.mobius.waila.plugin.harvest.provider.HarvestProvider;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(HarvestProvider.class)
+public class wthit_HarvestProviderMixin {
+
+    @Inject(method = "appendBody", at = @At("HEAD"), remap = false, cancellable = true)
+    private void polymer$disableHarvestTooltip(ITooltip tooltip, IBlockAccessor accessor, IPluginConfig config, CallbackInfo ci) {
+        if (InternalClientRegistry.getBlockAt(accessor.getPosition()) != ClientPolymerBlock.NONE_STATE) ci.cancel();
+    }
+
+}

--- a/polymer-core/src/main/resources/polymer-core.mixins.json
+++ b/polymer-core/src/main/resources/polymer-core.mixins.json
@@ -103,6 +103,7 @@
     "client.compat.emi_ItemStackMixin",
     "client.compat.jei_StackHelperMixin",
     "client.compat.rei_ItemEntryDefinitionMixin",
+    "client.compat.wthit_HarvestProviderMixin",
     "client.entity.EntityMixin",
     "client.item.ItemGroupMixin",
     "client.item.ItemGroupsMixin",


### PR DESCRIPTION
- Bypass blacklist (https://github.com/badasintended/wthit/issues/264)
- Fix outdated config key
- Re-enable icon override (it will show the fake block's item. Is this preferable than outright disabling it?)
- Disable harvest provider on polymer blocks (need an opinion on this)

![2024-05-27_00 38 31](https://github.com/Patbox/polymer/assets/21150434/648a1f0b-4065-47ff-8ace-11f702125054)
