### PR TITLE
add `contains(Identifier)` to PolymerItemGroupUtils

### DIFF
--- a/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemGroupUtils.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemGroupUtils.java
@@ -106,11 +106,17 @@ public final class PolymerItemGroupUtils {
     }
 
     public static void registerPolymerItemGroup(Identifier identifier, ItemGroup group) {
-        InternalServerRegistry.ITEM_GROUPS.set(identifier, group);
+        if (contains(identifier)) {
+            PolymerImpl.LOGGER.warn("ItemGroup '{}' is already registered!", identifier);
+        } else {
+            InternalServerRegistry.ITEM_GROUPS.set(identifier, group);
+        }
         if (Registries.ITEM_GROUP.containsId(identifier)) {
             PolymerImpl.LOGGER.warn("ItemGroup '{}' is already registered as vanilla!", identifier);
         }
     }
+
+    public static Boolean contains(Identifier identifier) { return InternalServerRegistry.ITEM_GROUPS.contains(identifier); }
 
     public static Identifier getId(ItemGroup group) {
         var x = REGISTRY.getId(group);


### PR DESCRIPTION
Ran into an issue where there was *no way* to check if a group already existed, nor is there a way I can find to modify an existing group... so I added this function and check to check if a group is already registered... kindof untested but should work

Ideally I would prefer to be able to have an `registerPolymerItemGroup` function that is capable of overwriting an existing group but I dont know where to even start for that