### PR TITLE
Update docs for new BlockModelTypes and document `requestEmpty`

### DIFF
--- a/docs/polymer-blocks/basics.md
+++ b/docs/polymer-blocks/basics.md
@@ -10,14 +10,6 @@ blocks on client yet.
 
 Every block type has its own functionality and behaviour:
 
-- `FULL_BLOCK` - Noteblocks, have full collision and don't allow transparency, (limit: 799)
-- `TRANSPARENT_BLOCK` - Mostly leaves, allow "cutout" textures, (limit: 104)
-- `FARMLAND_BLOCK` - Farmland blocks, (limit: 5!)
-- `VINES_BLOCK` - All centered vine blocks, Cave Vines, Twisted Vines and Weeping Vines, (limit: 100)
-- `PLANT_BLOCK` - Small plant blocks, sugarcane and saplings, (limit: 21)
-- `KELP_BLOCK` - Just kelp, (limit: 25)
-- `CACTUS_BLOCK` - Just cactus, (limit: 15!)
-
 - `FULL_BLOCK` - Noteblocks, have full collision and don't allow transparency, (limit: 1149)
 - `TRANSPARENT_BLOCK` - Leaf blocks, allow "cutout" textures, (limit: 52)
 - `TRANSPARENT_BLOCK_WATERLOGGED` - Waterlogged leaf blocks, allow "cutout" textures, (limit: 52)

--- a/docs/polymer-blocks/basics.md
+++ b/docs/polymer-blocks/basics.md
@@ -18,6 +18,42 @@ Every block type has its own functionality and behaviour:
 - `KELP_BLOCK` - Just kelp, (limit: 25)
 - `CACTUS_BLOCK` - Just cactus, (limit: 15!)
 
+- `FULL_BLOCK` - Noteblocks, have full collision and don't allow transparency, (limit: 1149)
+- `TRANSPARENT_BLOCK` - Leaf blocks, allow "cutout" textures, (limit: 52)
+- `TRANSPARENT_BLOCK_WATERLOGGED` - Waterlogged leaf blocks, allow "cutout" textures, (limit: 52)
+- `BIOME_TRANSPARENT_BLOCK` - Biome tinted leaf blocks, (limit: 78)
+- `BIOME_TRANSPARENT_BLOCK_WATERLOGGED` Waterlogged biome tinted leaf blocks- (limit: 65)
+- `FARMLAND_BLOCK` - Farmland blocks, (limit: 5)
+- `VINES_BLOCK` - All centered vine blocks, Cave Vines, Twisted Vines and Weeping Vines, (limit: 100)
+- `PLANT_BLOCK` - Small plant blocks, mostly saplings, (limit: 7)
+- `BIOME_PLANT_BLOCK` - Biome tinted plant blocks, mostly sugarcane (limit: 15)
+- `KELP_BLOCK` - Just kelp, (limit: 25)
+- `CACTUS_BLOCK` - Just cactus, (limit: 15)
+- `SCULK_SENSOR_BLOCK` - Sculk-sensor and it's calibarated variant, half block high, allows transparency, (limit: 150)
+- `SCULK_SENSOR_BLOCK_WATERLOGGED` - Waterlogged sculk-sensor and it's calibarated variant, half block high, allows transparency, (limit: 150)
+- `TRIPWIRE_BLOCK` - Just Tripwire, allows transparency, (limit: 32)
+- `TRIPWIRE_BLOCK_FLAT` - Flat tripwire block, allows transparency, (limit: 32)
+- `TOP_SLAB` - Top-slabs, (limit: 5)
+- `TOP_SLAB_WATERLOGGED` - Waterlogged top-slabs (limit: 5)
+- `BOTTOM_SLAB` - Bottom slabs, don't allow transparency, (limit: 5)
+- `BOTTOM_SLAB_WATERLOGGED` - Waterlogged bottom-slabs, don't allow transparency (limit: 5)
+- `TOP_TRAPDOOR` - Closed top trapdoor, (limit: 20)
+- `BOTTOM_TRAPDOOR` - Closed bottom trapdoor, (limit: 20)
+- `NORTH_TRAPDOOR` - Open trapdoor facing north, (limit: 20)
+- `EAST_TRAPDOOR` - Open trapdoor facing east, (limit: 20)
+- `SOUTH_TRAPDOOR` - Open trapdoor facing south, (limit: 20)
+- `WEST_TRAPDOOR` - Open trapdoor facing west, (limit: 20)
+- `TOP_TRAPDOOR_WATERLOGGED` - Waterlogged closed top trapdoor, (limit: 20)
+- `BOTTOM_TRAPDOOR_WATERLOGGED` - Waterlogged closed bottom top trapdoor, (limit: 20)
+- `NORTH_TRAPDOOR_WATERLOGGED` - Waterlogged open trapdoor facing north, (limit: 20)
+- `EAST_TRAPDOOR_WATERLOGGED` - Waterlogged open trapdoor facing east, (limit: 20)
+- `SOUTH_TRAPDOOR_WATERLOGGED` - Waterlogged open trapdoor facing south, (limit: 20)
+- `WEST_TRAPDOOR_WATERLOGGED` - Waterlogged open trapdoor facing west, (limit: 20)
+- `NORTH_DOOR` - Door-half facing north, (limit: 160)
+- `EAST_DOOR` - Door-half facing east, (limit: 160)
+- `SOUTH_DOOR` - Door-half facing south, (limit: 160)
+- `WEST_DOOR` - Door-half facing west, (limit: 160)
+
 They all are accessible from `BlockModelType` enum.
 
 ## Defining a global model
@@ -35,4 +71,8 @@ server resource pack. Remember that you still need to register your assets with 
 
 ### Just keep in mind
 Some block model types have very small amount of free BlockStates. For that reason, while making public registering blocks globally,
-please allow for disabling of them and handle running out of them for best compatibility and mod support! 
+please allow for disabling of them and handle running out of them for best compatibility and mod support!
+
+It is also possible to request an empty blockstate for a BlockModelType using `PolymerBlockResourceUtils.requestEmpty(BlockModelType type)`. This can be used to display custom blocks using display entities. Just be aware that display entities have a much higher performance impact on clients than normal blocks!
+
+Empty models are shared between mods. 


### PR DESCRIPTION
I tried to document the new block model types a bit