### PR TITLE
Adds support for SHA1 hashed resource packs

### DIFF
--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/AutoHost.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/AutoHost.java
@@ -103,7 +103,7 @@ public class AutoHost implements ModInitializer {
     }
 
     public static Path getPath(String path) {
-        if (path.equals("main.zip")) {
+        if (path.equals("main.zip") || path.equals(PolymerResourcePackMod.sha1 + ".zip")) {
             var mainPath = PolymerResourcePackUtils.getMainPath();
             if (PolymerResourcePackMod.useMainPath) {
                 return mainPath;

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/AutoHost.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/AutoHost.java
@@ -103,7 +103,11 @@ public class AutoHost implements ModInitializer {
     }
 
     public static Path getPath(String path) {
-        if (path.equals("main.zip") || path.equals(PolymerResourcePackMod.sha1 + ".zip")) {
+        String filePath = "main.zip";
+        if (provider instanceof AbstractProvider abs) {
+            filePath = "main_" + abs.hash + ".zip";
+        }
+        if (path.equals(filePath)) {
             var mainPath = PolymerResourcePackUtils.getMainPath();
             if (PolymerResourcePackMod.useMainPath) {
                 return mainPath;

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/AbstractProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/AbstractProvider.java
@@ -96,8 +96,7 @@ public abstract class AbstractProvider implements ResourcePackDataProvider {
 
     @Override
     public String getMainFilePath(PacketContext context) {
-        if (PolymerResourcePackMod.sha1 != null) return getAddress(context.getClientConnection(), PolymerResourcePackMod.sha1 + ".zip");
-        return getAddress(context.getClientConnection(), "main.zip");
+        return getAddress(context.getClientConnection(), "main_" + hash + ".zip");
     }
 
     protected abstract String getAddress(ClientConnection connection, String path);

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/AbstractProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/AbstractProvider.java
@@ -96,6 +96,7 @@ public abstract class AbstractProvider implements ResourcePackDataProvider {
 
     @Override
     public String getMainFilePath(PacketContext context) {
+        if (PolymerResourcePackMod.sha1 != null) return getAddress(context.getClientConnection(), PolymerResourcePackMod.sha1 + ".zip");
         return getAddress(context.getClientConnection(), "main.zip");
     }
 

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/StandaloneWebServerProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/StandaloneWebServerProvider.java
@@ -90,8 +90,8 @@ public class StandaloneWebServerProvider extends AbstractProvider  {
                 ) {
                     exchange.getResponseHeaders().add("Server", "polymer-autohost");
                     exchange.getResponseHeaders().add("Content-Type", "application/zip");
-                    if (PolymerResourcePackMod.sha1 != null)
-                        exchange.getResponseHeaders().add("Cache-Control", "public, max-age=31536000");
+                    //Might be worth putting the max-age in the config
+                    exchange.getResponseHeaders().add("Cache-Control", "public, max-age=31536000");
                     exchange.sendResponseHeaders(HttpStatus.SC_OK, size);
 
                     input.transferTo(output);

--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/StandaloneWebServerProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/StandaloneWebServerProvider.java
@@ -8,6 +8,7 @@ import com.sun.net.httpserver.HttpServer;
 import eu.pb4.polymer.autohost.impl.AutoHost;
 import eu.pb4.polymer.common.impl.CommonImpl;
 import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
+import eu.pb4.polymer.resourcepack.impl.PolymerResourcePackMod;
 import net.minecraft.network.ClientConnection;
 import net.minecraft.server.MinecraftServer;
 import org.apache.http.HttpStatus;
@@ -89,6 +90,8 @@ public class StandaloneWebServerProvider extends AbstractProvider  {
                 ) {
                     exchange.getResponseHeaders().add("Server", "polymer-autohost");
                     exchange.getResponseHeaders().add("Content-Type", "application/zip");
+                    if (PolymerResourcePackMod.sha1 != null)
+                        exchange.getResponseHeaders().add("Cache-Control", "public, max-age=31536000");
                     exchange.sendResponseHeaders(HttpStatus.SC_OK, size);
 
                     input.transferTo(output);

--- a/polymer-resource-pack/src/main/java/eu/pb4/polymer/resourcepack/impl/PolymerResourcePackMod.java
+++ b/polymer-resource-pack/src/main/java/eu/pb4/polymer/resourcepack/impl/PolymerResourcePackMod.java
@@ -1,6 +1,5 @@
 package eu.pb4.polymer.resourcepack.impl;
 
-import com.google.common.hash.Hashing;
 import com.mojang.brigadier.context.CommandContext;
 import eu.pb4.polymer.common.impl.CommonImpl;
 import eu.pb4.polymer.common.impl.CommonImplUtils;
@@ -21,7 +20,6 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.ApiStatus;
-import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -38,8 +36,6 @@ public class PolymerResourcePackMod implements ModInitializer, ClientModInitiali
 	public static boolean alreadyGeneration = false;
     public static final List<String> STATUS = new CopyOnWriteArrayList<>();
     public static boolean useMainPath = true;
-    @Nullable
-    public static String sha1;
 
     @Override
 	public void onInitialize() {
@@ -116,16 +112,6 @@ public class PolymerResourcePackMod implements ModInitializer, ClientModInitiali
                 server.execute(() -> {
                     alreadyGeneration = false;
                     if (success) {
-                        Path filePath = finalOutputPath;
-                        try {
-                            String sha1Value = com.google.common.io.Files.asByteSource(filePath.toFile()).hash(Hashing.sha1()).toString();
-                            if (!sha1Value.isEmpty()) PolymerResourcePackMod.sha1 = sha1Value;
-
-                        } catch (Exception e)
-                        {
-                            e.printStackTrace();
-                        }
-
                         messageConsumer.accept(Text.literal("[Polymer] Resource pack created successfully! You can find it in game folder as ")
                                 .append(Text.literal(PolymerResourcePackImpl.FILE_NAME)
                                         .setStyle(Style.EMPTY.withUnderline(true)

--- a/polymer-resource-pack/src/main/java/eu/pb4/polymer/resourcepack/impl/PolymerResourcePackMod.java
+++ b/polymer-resource-pack/src/main/java/eu/pb4/polymer/resourcepack/impl/PolymerResourcePackMod.java
@@ -1,5 +1,6 @@
 package eu.pb4.polymer.resourcepack.impl;
 
+import com.google.common.hash.Hashing;
 import com.mojang.brigadier.context.CommandContext;
 import eu.pb4.polymer.common.impl.CommonImpl;
 import eu.pb4.polymer.common.impl.CommonImplUtils;
@@ -20,6 +21,7 @@ import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -36,6 +38,8 @@ public class PolymerResourcePackMod implements ModInitializer, ClientModInitiali
 	public static boolean alreadyGeneration = false;
     public static final List<String> STATUS = new CopyOnWriteArrayList<>();
     public static boolean useMainPath = true;
+    @Nullable
+    public static String sha1;
 
     @Override
 	public void onInitialize() {
@@ -112,6 +116,16 @@ public class PolymerResourcePackMod implements ModInitializer, ClientModInitiali
                 server.execute(() -> {
                     alreadyGeneration = false;
                     if (success) {
+                        Path filePath = finalOutputPath;
+                        try {
+                            String sha1Value = com.google.common.io.Files.asByteSource(filePath.toFile()).hash(Hashing.sha1()).toString();
+                            if (!sha1Value.isEmpty()) PolymerResourcePackMod.sha1 = sha1Value;
+
+                        } catch (Exception e)
+                        {
+                            e.printStackTrace();
+                        }
+
                         messageConsumer.accept(Text.literal("[Polymer] Resource pack created successfully! You can find it in game folder as ")
                                 .append(Text.literal(PolymerResourcePackImpl.FILE_NAME)
                                         .setStyle(Style.EMPTY.withUnderline(true)


### PR DESCRIPTION
Adds support for serving resource packs with SHA1 hash filenames. This allows for better caching and prevents issues when the resource pack content changes. It computes the SHA1 hash of the generated resource pack and uses it as the filename, while also setting the Cache-Control header for longer caching.