### PR TITLE
Update docs to point to Fabric Docs instead of Fabric Wiki where possible

### DIFF
--- a/docs/polymer-core/blocks.md
+++ b/docs/polymer-core/blocks.md
@@ -1,7 +1,7 @@
 # Blocks
 !!! Note
     These docs will only take care about polymer-related part of creation of blocks.
-    You might want to see [official Fabric Wiki](https://fabricmc.net/wiki/tutorial:blocks)
+    You might want to see [official Fabric Docs](https://docs.fabricmc.net/develop/blocks/first-block)
     for more in depth look into how to create blocks. 
     You can skip some client side specific things, as it won't take effect server side 
     (for example models and textures).

--- a/docs/polymer-core/items.md
+++ b/docs/polymer-core/items.md
@@ -1,7 +1,7 @@
 # Items
 !!! Note
     These docs will only take care about polymer-related part of creation of items.
-    You might want to see [official Fabric Wiki](https://fabricmc.net/wiki/tutorial:items_docs)
+    You might want to see [official Fabric Docs](https://docs.fabricmc.net/develop/items/first-item)
     for more in depth look into how to create items. 
     You can skip some client side specific things, as it won't take effect server side (excluding
     item groups, as they can be used by other mods)


### PR DESCRIPTION
Docs are much more current than wiki. There's no docs for entities yet, so that wasn't updated.