### PR TITLE
Add CUSTOM_NAME handling for TippedArrowItem based on POTION_CONTENTS

### DIFF
--- a/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemUtils.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemUtils.java
@@ -463,6 +463,7 @@ public final class PolymerItemUtils {
                 if (
                         (item instanceof CompassItem && out.contains(DataComponentTypes.LODESTONE_TRACKER))
                                 || (item instanceof PotionItem && out.contains(DataComponentTypes.POTION_CONTENTS))
+                                || (item instanceof TippedArrowItem && out.contains(DataComponentTypes.POTION_CONTENTS))
                                 || (item instanceof PlayerHeadItem && out.contains(DataComponentTypes.PROFILE) && Objects.requireNonNull(out.get(DataComponentTypes.PROFILE)).getName().isPresent())
 
                 ) {

--- a/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemUtils.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemUtils.java
@@ -462,8 +462,7 @@ public final class PolymerItemUtils {
             if (!out.contains(DataComponentTypes.CUSTOM_NAME)) {
                 if (
                         (item instanceof CompassItem && out.contains(DataComponentTypes.LODESTONE_TRACKER))
-                                || (item instanceof PotionItem && out.contains(DataComponentTypes.POTION_CONTENTS))
-                                || (item instanceof TippedArrowItem && out.contains(DataComponentTypes.POTION_CONTENTS))
+                                || ((item instanceof PotionItem || item instanceof TippedArrowItem) && out.contains(DataComponentTypes.POTION_CONTENTS))
                                 || (item instanceof PlayerHeadItem && out.contains(DataComponentTypes.PROFILE) && Objects.requireNonNull(out.get(DataComponentTypes.PROFILE)).getName().isPresent())
 
                 ) {


### PR DESCRIPTION
Modify the client's ItemStack CUSTOM_NAME for TippedArrowItem in the same way as for PotionItem when POTION_CONTENTS is present.