### PR TITLE
Fix doc strings that accidentally weren't renamed

### DIFF
--- a/docs/polymer-networking/getting-started.md
+++ b/docs/polymer-networking/getting-started.md
@@ -12,6 +12,6 @@ dependencies {
 }
 ```
 
-For `[TAG]`/polymer-blocks version I recommend you checking [this maven](https://maven.nucleoid.xyz/eu/pb4/polymer-networking/).
+For `[TAG]`/polymer-networking version I recommend you checking [this maven](https://maven.nucleoid.xyz/eu/pb4/polymer-networking/).
 
 Latest version: ![version](https://img.shields.io/maven-metadata/v?color=%23579B67&label=&metadataUrl=https://maven.nucleoid.xyz/eu/pb4/polymer-networking/maven-metadata.xml)

--- a/docs/polymer-resource-pack/getting-started.md
+++ b/docs/polymer-resource-pack/getting-started.md
@@ -14,6 +14,6 @@ dependencies {
 }
 ```
 
-For `[TAG]`/polymer-blocks version I recommend you checking [this maven](https://maven.nucleoid.xyz/eu/pb4/polymer-resource-pack/).
+For `[TAG]`/polymer-resource-pack version I recommend you checking [this maven](https://maven.nucleoid.xyz/eu/pb4/polymer-resource-pack/).
 
 Latest version: ![version](https://img.shields.io/maven-metadata/v?color=%23579B67&label=&metadataUrl=https://maven.nucleoid.xyz/eu/pb4/polymer-resource-pack/maven-metadata.xml)

--- a/docs/polymer-virtual-entity/getting-started.md
+++ b/docs/polymer-virtual-entity/getting-started.md
@@ -15,6 +15,6 @@ dependencies {
 }
 ```
 
-For `[TAG]`/polymer-blocks version I recommend you checking [this maven](https://maven.nucleoid.xyz/eu/pb4/polymer-virtual-entity/).
+For `[TAG]`/polymer-virtual-entity version I recommend you checking [this maven](https://maven.nucleoid.xyz/eu/pb4/polymer-virtual-entity/).
 
 Latest version: ![version](https://img.shields.io/maven-metadata/v?color=%23579B67&label=&metadataUrl=https://maven.nucleoid.xyz/eu/pb4/polymer-networking/maven-metadata.xml)


### PR DESCRIPTION
I saw a small mistake in the docs and looking at the doc pages regarding the other Polymer modules those have this string set properly _(ex: polymer-core has `/polymer-core`)_

3 pages were affected, and I've fixed them.

I'm guessing this was a copy paste mistake, happens to the best of us ~~_(happens to me far too often haha)_~~

<img width="952" height="559" alt="image" src="https://github.com/user-attachments/assets/57b9395c-6210-4331-8166-9ee0939ac9ca" />
