### PR TITLE
Fix NPE in createItemStack during async serialization

### DIFF
--- a/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemUtils.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/api/item/PolymerItemUtils.java
@@ -14,6 +14,7 @@ import eu.pb4.polymer.core.api.other.PolymerComponent;
 import eu.pb4.polymer.core.api.utils.PolymerSyncedObject;
 import eu.pb4.polymer.core.api.utils.PolymerUtils;
 import eu.pb4.polymer.core.impl.PolymerImpl;
+import eu.pb4.polymer.core.impl.PolymerMod;
 import eu.pb4.polymer.core.impl.TransformingComponent;
 import eu.pb4.polymer.core.impl.compat.polymc.PolyMcUtils;
 import eu.pb4.polymer.core.mixin.NbtComponentAccessor;
@@ -39,6 +40,7 @@ import net.minecraft.server.world.ServerWorld;
 import net.minecraft.text.Style;
 import net.minecraft.text.Text;
 import net.minecraft.util.*;
+import net.minecraft.world.World;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
 import xyz.nucleoid.packettweaker.PacketContext;
@@ -438,7 +440,16 @@ public final class PolymerItemUtils {
             polymerItem.modifyBasePolymerItemStack(out, itemStack, context);
         }
 
-        var lookup = context.getRegistryWrapperLookup();
+        var lookupOrNull = context.getRegistryWrapperLookup();
+
+        if (lookupOrNull == null) {
+            var server = PolymerMod.getServer();
+            if (server != null) {
+                lookupOrNull = server.getRegistryManager();
+            }
+        }
+
+        var lookup = lookupOrNull;
 
         {
             var current = itemStack.get(DataComponentTypes.USE_COOLDOWN);

--- a/polymer-core/src/main/java/eu/pb4/polymer/core/impl/PolymerMod.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/impl/PolymerMod.java
@@ -14,18 +14,31 @@ import eu.pb4.polymer.core.impl.networking.PolymerServerProtocolHandler;
 import eu.pb4.polymer.core.impl.networking.entry.PolymerBlockEntry;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerLifecycleEvents;
 import net.minecraft.item.tooltip.TooltipType;
 import net.minecraft.item.ItemStack;
 import net.minecraft.registry.Registries;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.Nullable;
 
 
 @ApiStatus.Internal
 public class PolymerMod implements ModInitializer, ClientModInitializer {
+
+    private static MinecraftServer server;
+
+    public static @Nullable MinecraftServer getServer() {
+        return server;
+    }
+
 	@Override
 	public void onInitialize() {
+        ServerLifecycleEvents.SERVER_STARTING.register(s -> server = s);
+        ServerLifecycleEvents.SERVER_STOPPED.register(s -> server = null);
+
 		CommonImplUtils.registerCommands(Commands::register);
 		CommonImplUtils.registerDevCommands(Commands::registerDev);
 


### PR DESCRIPTION
### Issue
When external mods (such as Grim Anticheat) manually trigger `ItemStack` serialization using `RegistryFriendlyByteBuf` on async threads, Polymer's `PacketContext` fails to infer the active `RegistryWrapper.WrapperLookup`, resulting in it being `null`.

In 1.21+, `ItemStack` serialization (specifically for Codecs and NBT) requires a valid registry lookup. When `createItemStack` attempts to serialize the `POLYMER_STACK` NBT data, it calls `lookup.getOps(NbtOps.INSTANCE)`, causing a `NullPointerException` if the lookup is missing.

### Fix
1. Exposed the `MinecraftServer` instance via `PolymerMod.getServer()`.
2. Updated `PolymerItemUtils#createItemStack` to fall back to the global server `RegistryManager` if the context's lookup is null.

This ensures that items can be safely serialized by other mods or on async threads where a specific player context is unavailable.

Also I'd like to note that my users have reported that 1.21.8 works but not 1.21.10. I know the current branch is for 1.21.11. Can we get a backport for 1.21.10?