### PR TITLE
Fix Github actions and publish artifactId

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          21    # Latest version
+          25    # Latest version
         ]
         # and run on both Linux and Windows
         os: [ubuntu-latest]
@@ -33,7 +33,7 @@ jobs:
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '21' }} # Only upload artifacts built from LTS java on one OS
+        if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from LTS java on one OS
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 21
+          java-version: 25
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/build.gradle
+++ b/build.gradle
@@ -233,7 +233,7 @@ allprojects {
                 publications {
                     mavenJava(MavenPublication) {
                         groupId = rootProject.maven_group
-                        artifactId = project.base.archivesName
+                        artifactId = project.base.archivesName.get()
                         version = project.version
 
                         from components.java

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,8 @@ allprojects {
         // if it is present.
         // If you remove this line, sources will not be generated.
         withSourcesJar()
+        sourceCompatibility = JavaVersion.VERSION_25
+        targetCompatibility = JavaVersion.VERSION_25
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ loader_version=0.18.4
 loom_version=1.15-SNAPSHOT
 
 # Fabric API
-fabric_api_version=0.143.13+26.1
+fabric_api_version=0.143.14+26.1
 
 maven_group = eu.pb4
 


### PR DESCRIPTION
- `artifactId = project.base.archivesName` would evaluate to `extension 'base' property 'archivesName'` because it's now a `Property<String>` which as far as I understood it is a Lazy Property
- Both the build and release workflow still used JDK 21