### PR TITLE
Fix NullPointerException when Carpet fake players join (missing REGISTRY_ACCESS in PacketContext)

### DIFF
--- a/polymer-core/src/main/java/eu/pb4/polymer/core/mixin/block/packet/BlockEntityInfoMixin.java
+++ b/polymer-core/src/main/java/eu/pb4/polymer/core/mixin/block/packet/BlockEntityInfoMixin.java
@@ -21,6 +21,11 @@ public class BlockEntityInfoMixin {
             return original;
         }
 
-        return PolymerBlockUtils.transformBlockEntityNbt(x, blockEntity.getType(), original, x.orElseThrow(PacketContext.REGISTRY_ACCESS));
+        var registryAccess = x.get(PacketContext.REGISTRY_ACCESS);
+        if (registryAccess == null) {
+            PolymerImplUtils.warnMissingContextChunkPacket();
+            return original;
+        }
+        return PolymerBlockUtils.transformBlockEntityNbt(x, blockEntity.getType(), original, registryAccess);
     }
 }


### PR DESCRIPTION
Carpet fake players use FakeClientConnection which skips the normal login flow,
so REGISTRY_ACCESS is never set in the PacketContext.

The original code called orElseThrow() which crashes the server when a fake player loads chunks.
This fix adds a null check - if REGISTRY_ACCESS is missing, skip polymer processing and return the original NBT safely.

Fixes #257