### PR TITLE
Fix hashing in Autohost

### DIFF
--- a/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/AbstractProvider.java
+++ b/polymer-autohost/src/main/java/eu/pb4/polymer/autohost/impl/providers/AbstractProvider.java
@@ -1,14 +1,17 @@
 package eu.pb4.polymer.autohost.impl.providers;
 
+import com.google.common.hash.Hashing;
 import eu.pb4.polymer.autohost.api.AutoHostUtils;
 import eu.pb4.polymer.autohost.api.ResourcePackDataProvider;
 import eu.pb4.polymer.autohost.impl.AutoHost;
+import eu.pb4.polymer.resourcepack.api.PolymerResourcePackUtils;
 import net.minecraft.network.Connection;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
 import org.jspecify.annotations.Nullable;
 import net.fabricmc.fabric.api.networking.v1.context.PacketContext;
 
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -21,11 +24,28 @@ public abstract class AbstractProvider implements ResourcePackDataProvider {
 
     public void serverStarted(MinecraftServer minecraftServer) {
         this.enabled = true;
+        PolymerResourcePackUtils.RESOURCE_PACK_FINISHED_EVENT.register(_ -> updateHash());
     }
 
     @Override
     public void serverStopped(MinecraftServer server) {
 
+    }
+
+    protected boolean updateHash() {
+        try {
+            if (Files.exists(PolymerResourcePackUtils.getMainPath())) {
+                hash = com.google.common.io.Files.asByteSource(PolymerResourcePackUtils.getMainPath().toFile()).hash(Hashing.sha1()).toString();
+                size = Files.size(PolymerResourcePackUtils.getMainPath());
+                lastUpdate = Files.getLastModifiedTime(PolymerResourcePackUtils.getMainPath()).toMillis();
+                return true;
+            }
+        } catch (Exception _) {
+
+        }
+        hash = "";
+        size = 0;
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Polymer autohost autohosts the resourcepack, and there is an option in the config to add the hash of the resourcepack to the filename, which can be useful for uses like caching. However right now it simply adds a + to the end of the filename. This is seemingly caused by this diff here https://github.com/Patbox/polymer/commit/9b26523a6da65113647bb6a5458ec55e75eb5ebe#diff-a76fdf41be0344f6b95489404185cadccb354b65871716250f2ed1401e975c54L63-L76, which removes the updateHash method from the AbstractProvider.
This PR restores the function and calls it in the RESOURCE_PACK_FINISHED_EVENT.